### PR TITLE
Feature/openapi parsing

### DIFF
--- a/findex/src/main/java/com/codeit/findex/common/openapi/controller/ApiDataInitializer.java
+++ b/findex/src/main/java/com/codeit/findex/common/openapi/controller/ApiDataInitializer.java
@@ -1,0 +1,30 @@
+package com.codeit.findex.common.openapi.controller;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import com.codeit.findex.common.openapi.service.ApiIndexDataService;
+import com.codeit.findex.common.openapi.service.ApiIndexInfoService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ApiDataInitializer implements CommandLineRunner {
+
+	private final ApiIndexInfoService indexInfoService;
+	private final ApiIndexDataService indexDataService;
+
+	@Override
+	public void run(String... args) throws Exception {
+		System.out.println("Starting data collection...");
+
+		System.out.println("Step 1: Collecting IndexInfo data...");
+		indexInfoService.fetchAndSaveIndexInfo();
+
+		System.out.println("Step 2: Collecting IndexData...");
+		indexDataService.fetchAndSaveIndexData();
+
+		System.out.println("All data collection complete!");
+	}
+}

--- a/findex/src/main/java/com/codeit/findex/common/openapi/dto/ApiResponseDto.java
+++ b/findex/src/main/java/com/codeit/findex/common/openapi/dto/ApiResponseDto.java
@@ -1,0 +1,72 @@
+package com.codeit.findex.common.openapi.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ApiResponseDto {
+	private Response response;
+
+	@Getter
+	@Setter
+	@ToString
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public static class Response {
+		private Body body;
+	}
+
+	@Getter
+	@Setter
+	@ToString
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public static class Body {
+		private int totalCount;
+		private int numOfRows;
+		private int pageNo;
+		private Items items;
+	}
+
+	@Getter
+	@Setter
+	@ToString
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public static class Items {
+		private List<Item> item;
+	}
+
+	@Getter
+	@Setter
+	@ToString
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public static class Item {
+		private String basDt; // 기준일자
+		private String idxNm; // 지수명
+		private String idxCsf; // 지수분류
+		private String epyItmsCnt; // 채용종목수
+		private String clpr; // 종가
+		private String vs; // 대비
+		private String fltRt; // 등락률
+		private String mkp; // 시가
+		private String hipr; // 고가
+		private String lopr; // 저가
+		private String trqu; // 거래량
+		private String trPrc; // 거래대금
+		private String lstgMrktTotAmt; // 상장시가총액
+		private String lsYrEdVsFltRg; // 전년말대비_등락폭
+		private String lsYrEdVsFltRt; // 전년말대비_등락률
+		private String yrWRcrdHgst; // 연중기록최고
+		private String yrWRcrdHgstDt; // 연중기록최고일자
+		private String yrWRcrdLwst; // 연중기록최저
+		private String yrWRcrdLwstDt; // 연중기록최저일자
+		private String basPntm; // 기준시점
+		private String basIdx; // 기준지수
+	}
+}

--- a/findex/src/main/java/com/codeit/findex/common/openapi/entity/ApiIndexData.java
+++ b/findex/src/main/java/com/codeit/findex/common/openapi/entity/ApiIndexData.java
@@ -1,0 +1,83 @@
+package com.codeit.findex.common.openapi.entity;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "index_data", uniqueConstraints = {
+	@UniqueConstraint(columnNames = {"index_info_id", "base_date"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ApiIndexData {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "index_info_id", nullable = false)
+	private ApiIndexInfo indexInfo;
+
+	@Column(name = "base_date", nullable = false)
+	private LocalDate baseDate; // 기준일자 (basDt)
+
+	@Column(name = "closing_price", precision = 18, scale = 4)
+	private BigDecimal closingPrice; // 종가 (clpr)
+
+	@Column(name = "versus", precision = 18, scale = 4)
+	private BigDecimal priceChange; // 대비 (vs)
+
+	@Column(name = "fluctuation_rate", precision = 18, scale = 4)
+	private BigDecimal fluctuationRate; // 등락률 (fltRt)
+
+	@Column(name = "market_price", precision = 18, scale = 4)
+	private BigDecimal marketPrice; // 시가 (mkp)
+
+	@Column(name = "high_price", precision = 18, scale = 4)
+	private BigDecimal highPrice; // 고가 (hipr)
+
+	@Column(name = "low_price", precision = 18, scale = 4)
+	private BigDecimal lowPrice; // 저가 (lopr)
+
+	@Column(name = "trading_quantity")
+	private Long tradingVolume; // 거래량 (trqu)
+
+	@Column(name = "trading_price", precision = 21, scale = 0)
+	private BigDecimal transactionPrice; // 거래대금 (trPrc)
+
+	@Column(name = "market_total_amount", precision = 21, scale = 0)
+	private BigDecimal marketCap; // 상장시가총액 (lstgMrktTotAmt)
+
+	@Builder
+	public ApiIndexData(ApiIndexInfo indexInfo, LocalDate baseDate, BigDecimal closingPrice, BigDecimal priceChange,
+		BigDecimal fluctuationRate, BigDecimal marketPrice, BigDecimal highPrice, BigDecimal lowPrice,
+		Long tradingVolume, BigDecimal transactionPrice, BigDecimal marketCap) {
+		this.indexInfo = indexInfo;
+		this.baseDate = baseDate;
+		this.closingPrice = closingPrice;
+		this.priceChange = priceChange;
+		this.fluctuationRate = fluctuationRate;
+		this.marketPrice = marketPrice;
+		this.highPrice = highPrice;
+		this.lowPrice = lowPrice;
+		this.tradingVolume = tradingVolume;
+		this.transactionPrice = transactionPrice;
+		this.marketCap = marketCap;
+	}
+}

--- a/findex/src/main/java/com/codeit/findex/common/openapi/entity/ApiIndexInfo.java
+++ b/findex/src/main/java/com/codeit/findex/common/openapi/entity/ApiIndexInfo.java
@@ -1,0 +1,60 @@
+package com.codeit.findex.common.openapi.entity;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.codeit.findex.indexData.domain.IndexData;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "index_infos")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ApiIndexInfo {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "index_name", nullable = false, unique = true, length = 240)
+	private String indexName; // 지수명 (idxNm)
+
+	@Column(name = "index_classification", length = 20)
+	private String indexClassification; // 지수분류명 (idxCsf)
+
+	@Column(name = "employed_items_count")
+	private Integer employedItemsCount; // 채용종목 수 (epyItmsCnt)
+
+	@Column(name = "base_point_in_time")
+	private LocalDate basePointInTime; // 기준시점 (basPntm)
+
+	@Column(name = "base_index", precision = 18, scale = 4)
+	private BigDecimal baseIndex; // 기준지수 (basIdx)
+
+	@OneToMany(mappedBy = "indexInfo", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<IndexData> indexDataList = new ArrayList<>();
+
+	@Builder
+	public ApiIndexInfo(String indexName, String indexClassification, Integer employedItemsCount,
+		LocalDate basePointInTime, BigDecimal baseIndex) {
+		this.indexName = indexName;
+		this.indexClassification = indexClassification;
+		this.employedItemsCount = employedItemsCount;
+		this.basePointInTime = basePointInTime;
+		this.baseIndex = baseIndex;
+	}
+}

--- a/findex/src/main/java/com/codeit/findex/common/openapi/repository/ApiIndexDataRepository.java
+++ b/findex/src/main/java/com/codeit/findex/common/openapi/repository/ApiIndexDataRepository.java
@@ -1,0 +1,19 @@
+package com.codeit.findex.common.openapi.repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.codeit.findex.common.openapi.entity.ApiIndexData;
+import com.codeit.findex.common.openapi.entity.ApiIndexInfo;
+
+public interface ApiIndexDataRepository extends JpaRepository<ApiIndexData, Long> {
+
+	@Query("select d.baseDate from ApiIndexData d " +
+		"where d.indexInfo = :indexInfo and d.baseDate in :dates")
+	List<LocalDate> findExistingDates(@Param("indexInfo") ApiIndexInfo indexInfo,
+		@Param("dates") List<LocalDate> dates);
+}

--- a/findex/src/main/java/com/codeit/findex/common/openapi/repository/ApiIndexInfoRepository.java
+++ b/findex/src/main/java/com/codeit/findex/common/openapi/repository/ApiIndexInfoRepository.java
@@ -1,0 +1,15 @@
+package com.codeit.findex.common.openapi.repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.codeit.findex.common.openapi.entity.ApiIndexInfo;
+
+public interface ApiIndexInfoRepository extends JpaRepository<ApiIndexInfo, Long> {
+	List<ApiIndexInfo> findByIndexNameAndIndexClassification(String indexName, String indexClassification);
+
+	List<ApiIndexInfo> findByIndexNameAndIndexClassificationAndEmployedItemsCountAndBasePointInTime(
+		String indexName, String indexClassification, Integer employedItemsCount, LocalDate basePointInTime);
+}

--- a/findex/src/main/java/com/codeit/findex/common/openapi/service/ApiIndexDataService.java
+++ b/findex/src/main/java/com/codeit/findex/common/openapi/service/ApiIndexDataService.java
@@ -1,0 +1,212 @@
+package com.codeit.findex.common.openapi.service;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.codeit.findex.common.openapi.dto.ApiResponseDto;
+import com.codeit.findex.common.openapi.entity.ApiIndexData;
+import com.codeit.findex.common.openapi.entity.ApiIndexInfo;
+import com.codeit.findex.common.openapi.repository.ApiIndexDataRepository;
+import com.codeit.findex.common.openapi.repository.ApiIndexInfoRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ApiIndexDataService {
+
+	private final ApiIndexDataRepository indexDataRepository;
+	private final ApiIndexInfoRepository indexInfoRepository;
+	private final RestTemplate restTemplate = new RestTemplate();
+
+	@Value("${api.service-key}")
+	private String serviceKey;
+
+	@Value("${api.stock-url}")
+	private String apiUrl;
+
+	private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+	@Transactional
+	public void fetchAndSaveIndexData() {
+		try {
+			int pageNo = 1;
+			int numOfRows = 100000;
+			boolean hasMoreData = true;
+			int savedCount = 0;
+
+			while (hasMoreData) {
+				String url = buildApiUrl(pageNo, numOfRows);
+
+				// API 호출
+				ApiResponseDto response = restTemplate.getForObject(url, ApiResponseDto.class);
+
+				// 응답 데이터 검증
+				if (response != null && response.getResponse() != null
+					&& response.getResponse().getBody() != null
+					&& response.getResponse().getBody().getItems() != null) {
+
+					List<ApiResponseDto.Item> items = response.getResponse().getBody().getItems().getItem();
+
+					if (items != null && !items.isEmpty()) {
+						int inserted = saveIndexDataBatch(items);
+						savedCount += inserted;
+
+						int totalCount = response.getResponse().getBody().getTotalCount();
+						if (pageNo * numOfRows >= totalCount) {
+							hasMoreData = false;
+						} else {
+							pageNo++;
+						}
+					} else {
+						hasMoreData = false;
+					}
+				} else {
+					hasMoreData = false;
+				}
+			}
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to fetch index data", e);
+		}
+	}
+
+	private int saveIndexDataBatch(List<ApiResponseDto.Item> items) {
+		if (items == null || items.isEmpty())
+			return 0;
+
+		// indexInfo 캐시
+		Map<String, ApiIndexInfo> infoCache = new HashMap<>();
+
+		// 리스트로 배치 저장
+		List<ApiIndexData> batch = new ArrayList<>();
+
+		for (ApiResponseDto.Item item : items) {
+			LocalDate baseDate = parseDate(item.getBasDt());
+			if (baseDate == null)
+				continue;
+
+			String key = item.getIdxNm() + "_" + item.getIdxCsf();
+
+			ApiIndexInfo indexInfo = infoCache.computeIfAbsent(key, k -> {
+				List<ApiIndexInfo> found = indexInfoRepository.findByIndexNameAndIndexClassification(
+					item.getIdxNm(), item.getIdxCsf());
+
+				if (found.isEmpty()) {
+					ApiIndexInfo newInfo = ApiIndexInfo.builder()
+						.indexName(item.getIdxNm())
+						.indexClassification(item.getIdxCsf())
+						.employedItemsCount(parseInteger(item.getEpyItmsCnt()))
+						.basePointInTime(parseDate(item.getBasPntm()))
+						.baseIndex(parseBigDecimal(item.getBasIdx()))
+						.build();
+					return indexInfoRepository.save(newInfo);
+				} else {
+					return found.get(0);
+				}
+			});
+
+			batch.add(ApiIndexData.builder()
+				.indexInfo(indexInfo)
+				.baseDate(baseDate)
+				.closingPrice(parseBigDecimal(item.getClpr()))
+				.priceChange(parseBigDecimal(item.getVs()))
+				.fluctuationRate(parseBigDecimal(item.getFltRt()))
+				.marketPrice(parseBigDecimal(item.getMkp()))
+				.highPrice(parseBigDecimal(item.getHipr()))
+				.lowPrice(parseBigDecimal(item.getLopr()))
+				.tradingVolume(parseLong(item.getTrqu()))
+				.transactionPrice(parseBigDecimal(item.getTrPrc()))
+				.marketCap(parseBigDecimal(item.getLstgMrktTotAmt()))
+				.build());
+		}
+
+		// indexInfo 별로 baseDate 중복 체크
+		Map<ApiIndexInfo, List<LocalDate>> datesByInfo = batch.stream()
+			.collect(Collectors.groupingBy(ApiIndexData::getIndexInfo,
+				Collectors.mapping(ApiIndexData::getBaseDate, Collectors.toList())));
+
+		Set<String> existingKeys = new HashSet<>();
+		for (Map.Entry<ApiIndexInfo, List<LocalDate>> entry : datesByInfo.entrySet()) {
+			ApiIndexInfo info = entry.getKey();
+			List<LocalDate> dates = entry.getValue();
+			List<LocalDate> existingDates =
+				indexDataRepository.findExistingDates(info, dates);
+			existingDates.forEach(d -> existingKeys.add(info.getId() + "_" + d));
+		}
+
+		// 신규 데이터만 필터링
+		List<ApiIndexData> toInsert = batch.stream()
+			.filter(d -> !existingKeys.contains(d.getIndexInfo().getId() + "_" + d.getBaseDate()))
+			.toList();
+
+		if (!toInsert.isEmpty()) {
+			indexDataRepository.saveAll(toInsert);
+			return toInsert.size();
+		}
+		return 0;
+	}
+
+	private String buildApiUrl(int pageNo, int numOfRows) {
+		return UriComponentsBuilder.fromHttpUrl(apiUrl)
+			.queryParam("serviceKey", serviceKey)
+			.queryParam("resultType", "json")
+			.queryParam("pageNo", pageNo)
+			.queryParam("numOfRows", numOfRows)
+			.build(false)
+			.toUriString();
+	}
+
+	private Integer parseInteger(String value) {
+		if (value == null || value.trim().isEmpty())
+			return null;
+		try {
+			return Integer.parseInt(value.trim());
+		} catch (NumberFormatException e) {
+			return null;
+		}
+	}
+
+	private Long parseLong(String value) {
+		if (value == null || value.trim().isEmpty())
+			return null;
+		try {
+			return Long.parseLong(value.trim());
+		} catch (NumberFormatException e) {
+			return null;
+		}
+	}
+
+	private BigDecimal parseBigDecimal(String value) {
+		if (value == null || value.trim().isEmpty())
+			return null;
+		try {
+			return new BigDecimal(value.trim());
+		} catch (NumberFormatException e) {
+			return null;
+		}
+	}
+
+	private LocalDate parseDate(String value) {
+		if (value == null || value.trim().isEmpty())
+			return null;
+		try {
+			return LocalDate.parse(value.trim(), DATE_FORMATTER);
+		} catch (Exception e) {
+			return null;
+		}
+	}
+}

--- a/findex/src/main/java/com/codeit/findex/common/openapi/service/ApiIndexInfoService.java
+++ b/findex/src/main/java/com/codeit/findex/common/openapi/service/ApiIndexInfoService.java
@@ -1,0 +1,160 @@
+package com.codeit.findex.common.openapi.service;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.codeit.findex.common.openapi.dto.ApiResponseDto;
+import com.codeit.findex.common.openapi.entity.ApiIndexInfo;
+import com.codeit.findex.common.openapi.repository.ApiIndexInfoRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ApiIndexInfoService {
+
+	private final ApiIndexInfoRepository indexInfoRepository;
+	private final RestTemplate restTemplate = new RestTemplate();
+
+	@Value("${api.service-key}")
+	private String serviceKey;
+
+	@Value("${api.stock-url}")
+	private String apiUrl;
+
+	private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+	@Transactional
+	public void fetchAndSaveIndexInfo() {
+		try {
+			int pageNo = 1;
+			int numOfRows = 100000;
+			boolean hasMoreData = true;
+			int savedCount = 0;
+			int duplicateCount = 0;
+
+			while (hasMoreData) {
+				String url = buildApiUrl(pageNo, numOfRows);
+
+				// API 호출
+				ApiResponseDto response = restTemplate.getForObject(url, ApiResponseDto.class);
+
+				// 응답 데이터 검증
+				if (response != null && response.getResponse() != null
+					&& response.getResponse().getBody() != null
+					&& response.getResponse().getBody().getItems() != null) {
+
+					List<ApiResponseDto.Item> items = response.getResponse().getBody().getItems().getItem();
+
+					if (items != null && !items.isEmpty()) {
+						for (ApiResponseDto.Item item : items) {
+							if (saveIndexInfo(item)) {
+								savedCount++;
+							} else {
+								duplicateCount++;
+							}
+						}
+
+						// 다음 페이지 확인
+						int totalCount = response.getResponse().getBody().getTotalCount();
+						if (pageNo * numOfRows >= totalCount) {
+							hasMoreData = false;
+						} else {
+							pageNo++;
+						}
+					} else {
+						hasMoreData = false;
+					}
+				} else {
+					hasMoreData = false;
+				}
+			}
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to fetch index info data", e);
+		}
+	}
+
+	private boolean saveIndexInfo(ApiResponseDto.Item item) {
+		try {
+			String indexName = item.getIdxNm();
+			String indexClassification = item.getIdxCsf();
+			Integer employedItemsCount = parseInteger(item.getEpyItmsCnt());
+			LocalDate basePointInTime = parseDate(item.getBasPntm());
+
+			// 중복 데이터 확인
+			List<ApiIndexInfo> existingInfos = indexInfoRepository
+				.findByIndexNameAndIndexClassificationAndEmployedItemsCountAndBasePointInTime(
+					indexName, indexClassification, employedItemsCount, basePointInTime);
+
+			if (!existingInfos.isEmpty()) {
+				return false;
+			}
+
+			// 데이터 저장
+			ApiIndexInfo indexInfo = ApiIndexInfo.builder()
+				.indexName(indexName)
+				.indexClassification(indexClassification)
+				.employedItemsCount(employedItemsCount)
+				.basePointInTime(basePointInTime)
+				.baseIndex(parseBigDecimal(item.getBasIdx()))
+				.build();
+
+			indexInfoRepository.save(indexInfo);
+			return true;
+
+		} catch (Exception e) {
+			return false;
+		}
+	}
+
+	private String buildApiUrl(int pageNo, int numOfRows) {
+		return UriComponentsBuilder.fromHttpUrl(apiUrl)
+			.queryParam("serviceKey", serviceKey)
+			.queryParam("resultType", "json")
+			.queryParam("pageNo", pageNo)
+			.queryParam("numOfRows", numOfRows)
+			.build(false)
+			.toUriString();
+	}
+
+	private Integer parseInteger(String value) {
+		if (value == null || value.trim().isEmpty()) {
+			return null;
+		}
+		try {
+			return Integer.parseInt(value.trim());
+		} catch (NumberFormatException e) {
+			return null;
+		}
+	}
+
+	private BigDecimal parseBigDecimal(String value) {
+		if (value == null || value.trim().isEmpty()) {
+			return null;
+		}
+		try {
+			return new BigDecimal(value.trim());
+		} catch (NumberFormatException e) {
+			return null;
+		}
+	}
+
+	private LocalDate parseDate(String value) {
+		if (value == null || value.trim().isEmpty()) {
+			return null;
+		}
+		try {
+			return LocalDate.parse(value.trim(), DATE_FORMATTER);
+		} catch (Exception e) {
+			return null;
+		}
+	}
+}

--- a/findex/src/main/resources/application-local.yml
+++ b/findex/src/main/resources/application-local.yml
@@ -25,3 +25,8 @@ logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.orm.jdbc.bind: trace
+
+# API
+api:
+  service-key: ${API_SERVICE_KEY}
+  stock-url: ${API_URL}


### PR DESCRIPTION
### 작업 개요
금융데이터 API 데이터 파싱을 위한 코드 작업

### 작업 분류
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 상세 내용
1. erd에 맞춰서 응답 데이터를 저장한다.
2. 중복 저장을 막기 위해서 각 service  파일에 로직을 추가했다.
3. 보안을 위해 .env 파일에 서비스 키와 url을 저장하고 사용했다. (로컬 환경에서 각자 세팅이 필요) 

### 생각해볼 문제
1. index_data에 30000개가 저장되는 게 정확하게 맞는 수인지 확인을 못해봤다.
