### PR TITLE
feat: 지수 데이터 관리 API 기능 구현

### DIFF
--- a/findex/src/main/java/com/codeit/findex/FindexApplication.java
+++ b/findex/src/main/java/com/codeit/findex/FindexApplication.java
@@ -7,7 +7,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class FindexApplication {
 
 	public static void main(String[] args) {
+
 		SpringApplication.run(FindexApplication.class, args);
+		System.out.println("***************Index Service Started*****************");
 	}
 
 }

--- a/findex/src/main/java/com/codeit/findex/common/util/ApiLoggingAspect.java
+++ b/findex/src/main/java/com/codeit/findex/common/util/ApiLoggingAspect.java
@@ -22,3 +22,6 @@ public class ApiLoggingAspect {
 		System.out.println("API returned: " + methodName + " -> " + result);
 	}
 }
+
+// 데이터 목록 조회 + 데이터 등록 + 차트 조회 + 성과 랭킹 조회 + 연동 작업 목록 조회 (지인)
+// 데이터 삭제 + 데이터 수정 + 관심 지수 성과 조회 + 지수 데이터 CSV export + 지수 정보 연동 + 지수 데이터 연동 (수연)

--- a/findex/src/main/java/com/codeit/findex/indexData/controller/IndexChartController.java
+++ b/findex/src/main/java/com/codeit/findex/indexData/controller/IndexChartController.java
@@ -1,0 +1,40 @@
+package com.codeit.findex.indexData.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.codeit.findex.indexData.domain.PeriodType;
+import com.codeit.findex.indexData.dto.IndexChartResponse;
+import com.codeit.findex.indexData.service.IndexChartService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/index-data")
+@RequiredArgsConstructor
+public class IndexChartController {
+	private final IndexChartService indexChartService;
+
+	// 지수 차트 조회
+	@GetMapping("/{id}")
+	public ResponseEntity<IndexChartResponse> getIndexChartData(
+		@PathVariable("id") Long id,
+		@RequestParam(value = "periodType", required = false) String periodTypeStr) {
+
+		PeriodType periodType = null;
+		if (periodTypeStr != null && !periodTypeStr.isEmpty()) {
+			try {
+				periodType = PeriodType.valueOf(periodTypeStr.toUpperCase());
+			} catch (IllegalArgumentException e) {
+				throw new IllegalArgumentException("유효하지 않은 기간 유형입니다: " + periodTypeStr);
+			}
+		}
+
+		IndexChartResponse response = indexChartService.getIndexChartData(id, periodType);
+		return ResponseEntity.ok(response);
+	}
+}

--- a/findex/src/main/java/com/codeit/findex/indexData/controller/IndexDataController.java
+++ b/findex/src/main/java/com/codeit/findex/indexData/controller/IndexDataController.java
@@ -1,27 +1,15 @@
 package com.codeit.findex.indexData.controller;
 
-import java.time.LocalDate;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.springframework.data.domain.Page;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.codeit.findex.indexData.domain.IndexData;
-import com.codeit.findex.indexData.domain.PeriodType;
-import com.codeit.findex.indexData.dto.IndexChartResponse;
 import com.codeit.findex.indexData.dto.IndexDataRequestDto;
 import com.codeit.findex.indexData.dto.IndexDataResponseDto;
-import com.codeit.findex.indexData.dto.PagedResponseDto;
 import com.codeit.findex.indexData.service.IndexDataService;
 
 import lombok.RequiredArgsConstructor;
@@ -32,82 +20,11 @@ import lombok.RequiredArgsConstructor;
 public class IndexDataController {
 	private final IndexDataService indexDataService;
 
-	// 지수 데이터 목록 조회
-	@GetMapping
-	public ResponseEntity<PagedResponseDto<IndexDataResponseDto>> getIndexDataList(
-		@RequestParam(required = false) Long indexInfoId,
-		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
-		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
-		@RequestParam(required = false) String cursor,
-		@RequestParam(required = false) String idAfter,
-		@RequestParam(required = false, defaultValue = "baseDate") String sortField,
-		@RequestParam(required = false, defaultValue = "asc") String sortDirection,
-		@RequestParam(required = false, defaultValue = "10") Integer size) {
-
-		Long lastId = null;
-		if (cursor != null && !cursor.trim().isEmpty()) {
-			try {
-				lastId = Long.parseLong(cursor);
-			} catch (NumberFormatException ignored) {
-			}
-		} else if (idAfter != null && !idAfter.trim().isEmpty()) {
-			try {
-				lastId = Long.parseLong(idAfter);
-			} catch (NumberFormatException ignored) {
-			}
-		}
-
-		Page<IndexData> indexDataPage = indexDataService.getIndexDataList(
-			indexInfoId, startDate, endDate, lastId, sortField, sortDirection, size);
-
-		List<IndexDataResponseDto> content = indexDataPage.getContent().stream()
-			.map(IndexDataResponseDto::from)
-			.collect(Collectors.toList());
-
-		String nextCursor = null;
-		String nextIdAfter = null;
-		if (indexDataPage.hasNext() && !content.isEmpty()) {
-			Long lastIdInPage = content.get(content.size() - 1).getId();
-			nextCursor = lastIdInPage.toString();
-			nextIdAfter = lastIdInPage.toString();
-		}
-
-		PagedResponseDto<IndexDataResponseDto> response = PagedResponseDto.<IndexDataResponseDto>builder()
-			.content(content)
-			.nextCursor(nextCursor)
-			.nextIdAfter(nextIdAfter)
-			.size(content.size())
-			.totalElements((int)indexDataPage.getTotalElements())
-			.hasNext(indexDataPage.hasNext())
-			.build();
-
-		return ResponseEntity.ok(response);
-	}
-
 	// 지수 데이터 등록
 	@PostMapping
 	public ResponseEntity<IndexDataResponseDto> createIndexData(@RequestBody IndexDataRequestDto requestDto) {
 		IndexData createdIndexData = indexDataService.createIndexData(requestDto);
 		IndexDataResponseDto response = IndexDataResponseDto.from(createdIndexData);
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);
-	}
-
-	// 지수 차트 조회
-	@GetMapping("/{id}")
-	public ResponseEntity<IndexChartResponse> getIndexChartData(
-		@PathVariable("id") Long id,
-		@RequestParam(value = "periodType", required = false) String periodTypeStr) {
-
-		PeriodType periodType = null;
-		if (periodTypeStr != null && !periodTypeStr.isEmpty()) {
-			try {
-				periodType = PeriodType.valueOf(periodTypeStr.toUpperCase());
-			} catch (IllegalArgumentException e) {
-				throw new IllegalArgumentException("유효하지 않은 기간 유형입니다: " + periodTypeStr);
-			}
-		}
-
-		IndexChartResponse response = indexDataService.getIndexChartData(id, periodType);
-		return ResponseEntity.ok(response);
 	}
 }

--- a/findex/src/main/java/com/codeit/findex/indexData/controller/IndexDataController.java
+++ b/findex/src/main/java/com/codeit/findex/indexData/controller/IndexDataController.java
@@ -1,12 +1,10 @@
 package com.codeit.findex.indexData.controller;
 
-import java.time.LocalDate;
 import java.util.Base64;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,8 +13,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.codeit.findex.indexData.domain.IndexData;
 import com.codeit.findex.indexData.dto.IndexDataResponseDto;
+import com.codeit.findex.indexData.dto.PagedResponseDto;
 import com.codeit.findex.indexData.service.IndexDataService;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,20 +23,19 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class IndexDataController {
 	private final IndexDataService indexDataService;
-	private final ObjectMapper objectMapper = new ObjectMapper();
 
 	@GetMapping
 	public ResponseEntity<com.codeit.findex.indexData.dto.PagedResponseDto<IndexDataResponseDto>> getIndexDataList(
-		@RequestParam(required = false) Long indexInfoId,
-		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
-		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
-		@RequestParam(required = false) Long idAfter,
+		@RequestParam(required = false) Integer indexInfoId,
+		@RequestParam(required = false) String startDate,
+		@RequestParam(required = false) String endDate,
+		@RequestParam(required = false) Integer idAfter,
 		@RequestParam(required = false) String cursor,
 		@RequestParam(required = false, defaultValue = "id") String sortField,
 		@RequestParam(required = false, defaultValue = "asc") String sortDirection,
-		@RequestParam(required = false, defaultValue = "10") int size) {
+		@RequestParam(required = false, defaultValue = "10") Integer size) {
 
-		Long actualIdAfter = idAfter;
+		Integer actualIdAfter = idAfter;
 		if (cursor != null && !cursor.isEmpty()) {
 			actualIdAfter = decodeCursor(cursor);
 		}
@@ -53,24 +50,24 @@ public class IndexDataController {
 		String nextCursor = null;
 		String nextIdAfter = null;
 		if (indexDataPage.hasNext() && !content.isEmpty()) {
-			Long lastId = content.get(content.size() - 1).getId();
+			Integer lastId = content.get(content.size() - 1).getId();
 			nextCursor = encodeCursor(lastId);
 			nextIdAfter = encodeCursor(lastId);
 		}
 
-		com.codeit.findex.indexData.dto.PagedResponseDto<IndexDataResponseDto> response = com.codeit.findex.indexData.dto.PagedResponseDto.<IndexDataResponseDto>builder()
+		PagedResponseDto<IndexDataResponseDto> response = PagedResponseDto.<IndexDataResponseDto>builder()
 			.content(content)
 			.nextCursor(nextCursor)
 			.nextIdAfter(nextIdAfter)
 			.size(content.size())
-			.totalElements(indexDataPage.getTotalElements())
+			.totalElements((int)indexDataPage.getTotalElements())
 			.hasNext(indexDataPage.hasNext())
 			.build();
 
 		return ResponseEntity.ok(response);
 	}
 
-	private String encodeCursor(Long id) {
+	private String encodeCursor(Integer id) {
 		try {
 			String json = String.format("{\"id\":%d}", id);
 			return Base64.getEncoder().encodeToString(json.getBytes());
@@ -79,11 +76,11 @@ public class IndexDataController {
 		}
 	}
 
-	private Long decodeCursor(String cursor) {
+	private Integer decodeCursor(String cursor) {
 		try {
 			String json = new String(Base64.getDecoder().decode(cursor));
 			String idStr = json.replaceAll("[{}\"id:]", "");
-			return Long.parseLong(idStr.trim());
+			return Integer.parseInt(idStr.trim());
 		} catch (Exception e) {
 			return null;
 		}

--- a/findex/src/main/java/com/codeit/findex/indexData/controller/IndexDataController.java
+++ b/findex/src/main/java/com/codeit/findex/indexData/controller/IndexDataController.java
@@ -1,9 +1,22 @@
 package com.codeit.findex.indexData.controller;
 
+import java.time.LocalDate;
+import java.util.Base64;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.codeit.findex.indexData.domain.IndexData;
+import com.codeit.findex.indexData.dto.IndexDataResponseDto;
 import com.codeit.findex.indexData.service.IndexDataService;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
 
@@ -12,4 +25,70 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class IndexDataController {
 	private final IndexDataService indexDataService;
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@GetMapping
+	public ResponseEntity<com.codeit.findex.indexData.dto.PagedResponseDto<IndexDataResponseDto>> getIndexDataList(
+		@RequestParam(required = false) Long indexInfoId,
+		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+		@RequestParam(required = false) Long idAfter,
+		@RequestParam(required = false) String cursor,
+		@RequestParam(required = false, defaultValue = "id") String sortField,
+		@RequestParam(required = false, defaultValue = "asc") String sortDirection,
+		@RequestParam(required = false, defaultValue = "10") int size) {
+
+		// cursor가 있으면 cursor에서 idAfter 추출
+		Long actualIdAfter = idAfter;
+		if (cursor != null && !cursor.isEmpty()) {
+			actualIdAfter = decodeCursor(cursor);
+		}
+
+		Page<IndexData> indexDataPage = indexDataService.getIndexDataList(
+			indexInfoId, startDate, endDate, actualIdAfter, sortField, sortDirection, size);
+
+		List<IndexDataResponseDto> content = indexDataPage.getContent().stream()
+			.map(IndexDataResponseDto::from)
+			.collect(Collectors.toList());
+
+		// 다음 페이지가 있으면 cursor 생성
+		String nextCursor = null;
+		String nextIdAfter = null;
+		if (indexDataPage.hasNext() && !content.isEmpty()) {
+			Long lastId = content.get(content.size() - 1).getId();
+			nextCursor = encodeCursor(lastId);
+			nextIdAfter = encodeCursor(lastId);
+		}
+
+		com.codeit.findex.indexData.dto.PagedResponseDto<IndexDataResponseDto> response = com.codeit.findex.indexData.dto.PagedResponseDto.<IndexDataResponseDto>builder()
+			.content(content)
+			.nextCursor(nextCursor)
+			.nextIdAfter(nextIdAfter)
+			.size(content.size())
+			.totalElements(indexDataPage.getTotalElements())
+			.hasNext(indexDataPage.hasNext())
+			.build();
+
+		return ResponseEntity.ok(response);
+	}
+
+	private String encodeCursor(Long id) {
+		try {
+			String json = String.format("{\"id\":%d}", id);
+			return Base64.getEncoder().encodeToString(json.getBytes());
+		} catch (Exception e) {
+			return null;
+		}
+	}
+
+	private Long decodeCursor(String cursor) {
+		try {
+			String json = new String(Base64.getDecoder().decode(cursor));
+			// 간단한 JSON 파싱 ({"id":20} 형태)
+			String idStr = json.replaceAll("[{}\"id:]", "");
+			return Long.parseLong(idStr.trim());
+		} catch (Exception e) {
+			return null;
+		}
+	}
 }

--- a/findex/src/main/java/com/codeit/findex/indexData/controller/IndexDataController.java
+++ b/findex/src/main/java/com/codeit/findex/indexData/controller/IndexDataController.java
@@ -38,7 +38,6 @@ public class IndexDataController {
 		@RequestParam(required = false, defaultValue = "asc") String sortDirection,
 		@RequestParam(required = false, defaultValue = "10") int size) {
 
-		// cursor가 있으면 cursor에서 idAfter 추출
 		Long actualIdAfter = idAfter;
 		if (cursor != null && !cursor.isEmpty()) {
 			actualIdAfter = decodeCursor(cursor);
@@ -51,7 +50,6 @@ public class IndexDataController {
 			.map(IndexDataResponseDto::from)
 			.collect(Collectors.toList());
 
-		// 다음 페이지가 있으면 cursor 생성
 		String nextCursor = null;
 		String nextIdAfter = null;
 		if (indexDataPage.hasNext() && !content.isEmpty()) {
@@ -84,7 +82,6 @@ public class IndexDataController {
 	private Long decodeCursor(String cursor) {
 		try {
 			String json = new String(Base64.getDecoder().decode(cursor));
-			// 간단한 JSON 파싱 ({"id":20} 형태)
 			String idStr = json.replaceAll("[{}\"id:]", "");
 			return Long.parseLong(idStr.trim());
 		} catch (Exception e) {

--- a/findex/src/main/java/com/codeit/findex/indexData/controller/IndexDataController.java
+++ b/findex/src/main/java/com/codeit/findex/indexData/controller/IndexDataController.java
@@ -1,17 +1,25 @@
 package com.codeit.findex.indexData.controller;
 
-import java.util.Base64;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.codeit.findex.indexData.domain.IndexData;
+import com.codeit.findex.indexData.domain.PeriodType;
+import com.codeit.findex.indexData.dto.IndexChartResponse;
+import com.codeit.findex.indexData.dto.IndexDataRequestDto;
 import com.codeit.findex.indexData.dto.IndexDataResponseDto;
 import com.codeit.findex.indexData.dto.PagedResponseDto;
 import com.codeit.findex.indexData.service.IndexDataService;
@@ -24,24 +32,33 @@ import lombok.RequiredArgsConstructor;
 public class IndexDataController {
 	private final IndexDataService indexDataService;
 
+	// 지수 데이터 목록 조회
 	@GetMapping
-	public ResponseEntity<com.codeit.findex.indexData.dto.PagedResponseDto<IndexDataResponseDto>> getIndexDataList(
-		@RequestParam(required = false) Integer indexInfoId,
-		@RequestParam(required = false) String startDate,
-		@RequestParam(required = false) String endDate,
-		@RequestParam(required = false) Integer idAfter,
+	public ResponseEntity<PagedResponseDto<IndexDataResponseDto>> getIndexDataList(
+		@RequestParam(required = false) Long indexInfoId,
+		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
 		@RequestParam(required = false) String cursor,
-		@RequestParam(required = false, defaultValue = "id") String sortField,
+		@RequestParam(required = false) String idAfter,
+		@RequestParam(required = false, defaultValue = "baseDate") String sortField,
 		@RequestParam(required = false, defaultValue = "asc") String sortDirection,
 		@RequestParam(required = false, defaultValue = "10") Integer size) {
 
-		Integer actualIdAfter = idAfter;
-		if (cursor != null && !cursor.isEmpty()) {
-			actualIdAfter = decodeCursor(cursor);
+		Long lastId = null;
+		if (cursor != null && !cursor.trim().isEmpty()) {
+			try {
+				lastId = Long.parseLong(cursor);
+			} catch (NumberFormatException ignored) {
+			}
+		} else if (idAfter != null && !idAfter.trim().isEmpty()) {
+			try {
+				lastId = Long.parseLong(idAfter);
+			} catch (NumberFormatException ignored) {
+			}
 		}
 
 		Page<IndexData> indexDataPage = indexDataService.getIndexDataList(
-			indexInfoId, startDate, endDate, actualIdAfter, sortField, sortDirection, size);
+			indexInfoId, startDate, endDate, lastId, sortField, sortDirection, size);
 
 		List<IndexDataResponseDto> content = indexDataPage.getContent().stream()
 			.map(IndexDataResponseDto::from)
@@ -50,9 +67,9 @@ public class IndexDataController {
 		String nextCursor = null;
 		String nextIdAfter = null;
 		if (indexDataPage.hasNext() && !content.isEmpty()) {
-			Integer lastId = content.get(content.size() - 1).getId();
-			nextCursor = encodeCursor(lastId);
-			nextIdAfter = encodeCursor(lastId);
+			Long lastIdInPage = content.get(content.size() - 1).getId();
+			nextCursor = lastIdInPage.toString();
+			nextIdAfter = lastIdInPage.toString();
 		}
 
 		PagedResponseDto<IndexDataResponseDto> response = PagedResponseDto.<IndexDataResponseDto>builder()
@@ -67,22 +84,30 @@ public class IndexDataController {
 		return ResponseEntity.ok(response);
 	}
 
-	private String encodeCursor(Integer id) {
-		try {
-			String json = String.format("{\"id\":%d}", id);
-			return Base64.getEncoder().encodeToString(json.getBytes());
-		} catch (Exception e) {
-			return null;
-		}
+	// 지수 데이터 등록
+	@PostMapping
+	public ResponseEntity<IndexDataResponseDto> createIndexData(@RequestBody IndexDataRequestDto requestDto) {
+		IndexData createdIndexData = indexDataService.createIndexData(requestDto);
+		IndexDataResponseDto response = IndexDataResponseDto.from(createdIndexData);
+		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 	}
 
-	private Integer decodeCursor(String cursor) {
-		try {
-			String json = new String(Base64.getDecoder().decode(cursor));
-			String idStr = json.replaceAll("[{}\"id:]", "");
-			return Integer.parseInt(idStr.trim());
-		} catch (Exception e) {
-			return null;
+	// 지수 차트 조회
+	@GetMapping("/{id}")
+	public ResponseEntity<IndexChartResponse> getIndexChartData(
+		@PathVariable("id") Long id,
+		@RequestParam(value = "periodType", required = false) String periodTypeStr) {
+
+		PeriodType periodType = null;
+		if (periodTypeStr != null && !periodTypeStr.isEmpty()) {
+			try {
+				periodType = PeriodType.valueOf(periodTypeStr.toUpperCase());
+			} catch (IllegalArgumentException e) {
+				throw new IllegalArgumentException("유효하지 않은 기간 유형입니다: " + periodTypeStr);
+			}
 		}
+
+		IndexChartResponse response = indexDataService.getIndexChartData(id, periodType);
+		return ResponseEntity.ok(response);
 	}
 }

--- a/findex/src/main/java/com/codeit/findex/indexData/controller/IndexDataQueryController.java
+++ b/findex/src/main/java/com/codeit/findex/indexData/controller/IndexDataQueryController.java
@@ -1,0 +1,79 @@
+package com.codeit.findex.indexData.controller;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.codeit.findex.indexData.domain.IndexData;
+import com.codeit.findex.indexData.dto.IndexDataResponseDto;
+import com.codeit.findex.indexData.dto.PagedResponseDto;
+import com.codeit.findex.indexData.service.IndexDataQueryService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/index-data")
+@RequiredArgsConstructor
+public class IndexDataQueryController {
+	private final IndexDataQueryService indexDataQueryService;
+
+	// 지수 데이터 목록 조회
+	@GetMapping
+	public ResponseEntity<PagedResponseDto<IndexDataResponseDto>> getIndexDataList(
+		@RequestParam(required = false) Long indexInfoId,
+		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+		@RequestParam(required = false) String cursor,
+		@RequestParam(required = false) String idAfter,
+		@RequestParam(required = false, defaultValue = "baseDate") String sortField,
+		@RequestParam(required = false, defaultValue = "asc") String sortDirection,
+		@RequestParam(required = false, defaultValue = "10") Integer size) {
+
+		Long lastId = null;
+		if (cursor != null && !cursor.trim().isEmpty()) {
+			try {
+				lastId = Long.parseLong(cursor);
+			} catch (NumberFormatException ignored) {
+			}
+		} else if (idAfter != null && !idAfter.trim().isEmpty()) {
+			try {
+				lastId = Long.parseLong(idAfter);
+			} catch (NumberFormatException ignored) {
+			}
+		}
+
+		Page<IndexData> indexDataPage = indexDataQueryService.getIndexDataList(
+			indexInfoId, startDate, endDate, lastId, sortField, sortDirection, size);
+
+		List<IndexDataResponseDto> content = indexDataPage.getContent().stream()
+			.map(IndexDataResponseDto::from)
+			.collect(Collectors.toList());
+
+		String nextCursor = null;
+		String nextIdAfter = null;
+		if (indexDataPage.hasNext() && !content.isEmpty()) {
+			Long lastIdInPage = content.get(content.size() - 1).getId();
+			nextCursor = lastIdInPage.toString();
+			nextIdAfter = lastIdInPage.toString();
+		}
+
+		PagedResponseDto<IndexDataResponseDto> response = PagedResponseDto.<IndexDataResponseDto>builder()
+			.content(content)
+			.nextCursor(nextCursor)
+			.nextIdAfter(nextIdAfter)
+			.size(content.size())
+			.totalElements((int)indexDataPage.getTotalElements())
+			.hasNext(indexDataPage.hasNext())
+			.build();
+
+		return ResponseEntity.ok(response);
+	}
+}

--- a/findex/src/main/java/com/codeit/findex/indexData/controller/IndexPerformanceController.java
+++ b/findex/src/main/java/com/codeit/findex/indexData/controller/IndexPerformanceController.java
@@ -1,0 +1,51 @@
+package com.codeit.findex.indexData.controller;
+
+import com.codeit.findex.indexData.domain.PerformancePeriodType;
+import com.codeit.findex.indexData.dto.IndexPerformanceRankResponse;
+import com.codeit.findex.indexData.service.IndexPerformanceService;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/index-data")
+@RequiredArgsConstructor
+public class IndexPerformanceController {
+
+	private final IndexPerformanceService indexPerformanceService;
+
+	/**
+	 * 지수 성과 랭킹 조회
+	 *
+	 * @param indexInfoId 지수 정보 ID (선택)
+	 * @param periodTypeStr 성과 기간 유형 (DAILY, WEEKLY, MONTHLY)
+	 * @param limit 최대 랭킹 수
+	 * @return 성과 랭킹 목록
+	 */
+	@GetMapping("/performance/rank")
+	public ResponseEntity<List<IndexPerformanceRankResponse>> getPerformanceRanking(
+		@RequestParam(value = "indexInfoId", required = false) Long indexInfoId,
+		@RequestParam(value = "periodType", required = false) String periodTypeStr,
+		@RequestParam(value = "limit", required = false) Integer limit) {
+
+		// 성과 기간 유형 파싱
+		PerformancePeriodType periodType = null;
+		if (periodTypeStr != null && !periodTypeStr.isEmpty()) {
+			try {
+				periodType = PerformancePeriodType.valueOf(periodTypeStr.toUpperCase());
+			} catch (IllegalArgumentException e) {
+				throw new IllegalArgumentException("유효하지 않은 성과 기간 유형입니다: " + periodTypeStr);
+			}
+		}
+
+		// 서비스 호출
+		List<IndexPerformanceRankResponse> rankings =
+			indexPerformanceService.getPerformanceRanking(indexInfoId, periodType, limit);
+
+		return ResponseEntity.ok(rankings);
+	}
+}

--- a/findex/src/main/java/com/codeit/findex/indexData/domain/IndexData.java
+++ b/findex/src/main/java/com/codeit/findex/indexData/domain/IndexData.java
@@ -52,6 +52,9 @@ public class IndexData {
 	@Column(name = "low_price", precision = 18, scale = 4)
 	private BigDecimal lowPrice;
 
+	@Column(name = "versus", precision = 18, scale = 4)
+	private BigDecimal versus;
+
 	@Column(name = "fluctuation_rate", precision = 18, scale = 4)
 	private BigDecimal fluctuationRate;
 

--- a/findex/src/main/java/com/codeit/findex/indexData/domain/PerformancePeriodType.java
+++ b/findex/src/main/java/com/codeit/findex/indexData/domain/PerformancePeriodType.java
@@ -1,0 +1,7 @@
+package com.codeit.findex.indexData.domain;
+
+public enum PerformancePeriodType {
+	DAILY,    // 전일 대비
+	WEEKLY,   // 전주 대비
+	MONTHLY   // 전월 대비
+}

--- a/findex/src/main/java/com/codeit/findex/indexData/domain/PeriodType.java
+++ b/findex/src/main/java/com/codeit/findex/indexData/domain/PeriodType.java
@@ -1,0 +1,7 @@
+package com.codeit.findex.indexData.domain;
+
+public enum PeriodType {
+	MONTHLY,
+	QUARTERLY,
+	YEARLY
+}

--- a/findex/src/main/java/com/codeit/findex/indexData/dto/IndexChartResponse.java
+++ b/findex/src/main/java/com/codeit/findex/indexData/dto/IndexChartResponse.java
@@ -1,0 +1,31 @@
+package com.codeit.findex.indexData.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class IndexChartResponse {
+	private Long indexInfoId;
+	private String indexClassification;
+	private String indexName;
+	private String periodType;
+	private List<DataPoint> dataPoints;
+	private List<DataPoint> ma5DataPoints;
+	private List<DataPoint> ma20DataPoints;
+
+	@Getter
+	@Builder
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class DataPoint {
+		private String date;
+		private Float value;
+	}
+}

--- a/findex/src/main/java/com/codeit/findex/indexData/dto/IndexDataRequestDto.java
+++ b/findex/src/main/java/com/codeit/findex/indexData/dto/IndexDataRequestDto.java
@@ -1,0 +1,51 @@
+package com.codeit.findex.indexData.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
+import com.codeit.findex.indexData.domain.IndexData;
+import com.codeit.findex.indexInfo.domain.IndexInfo;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class IndexDataRequestDto {
+	private Long indexInfoId;
+	@DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+	private LocalDate baseDate;
+	private String sourceType;
+	private Double marketPrice;
+	private Double closingPrice;
+	private Double highPrice;
+	private Double lowPrice;
+	private Double versus;
+	private Double fluctuationRate;
+	private Long tradingQuantity;
+	private Double tradingPrice;
+	private Double marketTotalAmount;
+
+	public IndexData toEntity(IndexInfo indexInfo) {
+		return IndexData.builder()
+			.indexInfo(indexInfo)
+			.baseDate(this.baseDate)
+			.sourceType(this.sourceType)
+			.marketPrice(this.marketPrice != null ? BigDecimal.valueOf(this.marketPrice) : null)
+			.closingPrice(this.closingPrice != null ? BigDecimal.valueOf(this.closingPrice) : null)
+			.highPrice(this.highPrice != null ? BigDecimal.valueOf(this.highPrice) : null)
+			.lowPrice(this.lowPrice != null ? BigDecimal.valueOf(this.lowPrice) : null)
+			.versus(this.versus != null ? BigDecimal.valueOf(this.versus) : null)
+			.fluctuationRate(this.fluctuationRate != null ? BigDecimal.valueOf(this.fluctuationRate) : null)
+			.tradingQuantity(this.tradingQuantity)
+			.tradingPrice(this.tradingPrice != null ? BigDecimal.valueOf(this.tradingPrice) : null)
+			.marketTotalAmount(this.marketTotalAmount != null ? BigDecimal.valueOf(this.marketTotalAmount) : null)
+			.build();
+	}
+}

--- a/findex/src/main/java/com/codeit/findex/indexData/dto/IndexDataResponseDto.java
+++ b/findex/src/main/java/com/codeit/findex/indexData/dto/IndexDataResponseDto.java
@@ -1,0 +1,48 @@
+package com.codeit.findex.indexData.dto;
+
+import com.codeit.findex.indexData.domain.IndexData;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class IndexDataResponseDto {
+	private Integer id;
+	private Integer indexInfoId;
+	private String baseDate;
+	private String sourceType;
+	private Double marketPrice;
+	private Double closingPrice;
+	private Double highPrice;
+	private Double lowPrice;
+	private Double versus;
+	private Double fluctuationRate;
+	private Integer tradingQuantity;
+	private Integer tradingPrice;
+	private Integer marketTotalAmount;
+
+	public static IndexDataResponseDto from(IndexData indexData) {
+		return IndexDataResponseDto.builder()
+			.id(indexData.getId() != null ? indexData.getId().intValue() : null)
+			.indexInfoId(indexData.getIndexInfo() != null ? indexData.getIndexInfo().getId().intValue() : null)
+			.baseDate(indexData.getBaseDate() != null ? indexData.getBaseDate().toString() : null)
+			.sourceType(indexData.getSourceType())
+			.marketPrice(indexData.getMarketPrice() != null ? indexData.getMarketPrice().doubleValue() : null)
+			.closingPrice(indexData.getClosingPrice() != null ? indexData.getClosingPrice().doubleValue() : null)
+			.highPrice(indexData.getHighPrice() != null ? indexData.getHighPrice().doubleValue() : null)
+			.lowPrice(indexData.getLowPrice() != null ? indexData.getLowPrice().doubleValue() : null)
+			.versus(indexData.getVersus() != null ? indexData.getVersus().doubleValue() : null)
+			.fluctuationRate(
+				indexData.getFluctuationRate() != null ? indexData.getFluctuationRate().doubleValue() : null)
+			.tradingQuantity(indexData.getTradingQuantity() != null ? indexData.getTradingQuantity().intValue() : null)
+			.tradingPrice(indexData.getTradingPrice() != null ? indexData.getTradingPrice().intValue() : null)
+			.marketTotalAmount(
+				indexData.getMarketTotalAmount() != null ? indexData.getMarketTotalAmount().intValue() : null)
+			.build();
+	}
+}

--- a/findex/src/main/java/com/codeit/findex/indexData/dto/IndexDataResponseDto.java
+++ b/findex/src/main/java/com/codeit/findex/indexData/dto/IndexDataResponseDto.java
@@ -1,5 +1,7 @@
 package com.codeit.findex.indexData.dto;
 
+import java.time.LocalDate;
+
 import com.codeit.findex.indexData.domain.IndexData;
 
 import lombok.AllArgsConstructor;
@@ -12,9 +14,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class IndexDataResponseDto {
-	private Integer id;
-	private Integer indexInfoId;
-	private String baseDate;
+	private Long id;
+	private Long indexInfoId;
+	private LocalDate baseDate;
 	private String sourceType;
 	private Double marketPrice;
 	private Double closingPrice;
@@ -22,15 +24,15 @@ public class IndexDataResponseDto {
 	private Double lowPrice;
 	private Double versus;
 	private Double fluctuationRate;
-	private Integer tradingQuantity;
-	private Integer tradingPrice;
-	private Integer marketTotalAmount;
+	private Long tradingQuantity;
+	private Double tradingPrice;
+	private Double marketTotalAmount;
 
 	public static IndexDataResponseDto from(IndexData indexData) {
 		return IndexDataResponseDto.builder()
-			.id(indexData.getId() != null ? indexData.getId().intValue() : null)
-			.indexInfoId(indexData.getIndexInfo() != null ? indexData.getIndexInfo().getId().intValue() : null)
-			.baseDate(indexData.getBaseDate() != null ? indexData.getBaseDate().toString() : null)
+			.id(indexData.getId())
+			.indexInfoId(indexData.getIndexInfo() != null ? indexData.getIndexInfo().getId() : null)
+			.baseDate(indexData.getBaseDate())
 			.sourceType(indexData.getSourceType())
 			.marketPrice(indexData.getMarketPrice() != null ? indexData.getMarketPrice().doubleValue() : null)
 			.closingPrice(indexData.getClosingPrice() != null ? indexData.getClosingPrice().doubleValue() : null)
@@ -39,10 +41,10 @@ public class IndexDataResponseDto {
 			.versus(indexData.getVersus() != null ? indexData.getVersus().doubleValue() : null)
 			.fluctuationRate(
 				indexData.getFluctuationRate() != null ? indexData.getFluctuationRate().doubleValue() : null)
-			.tradingQuantity(indexData.getTradingQuantity() != null ? indexData.getTradingQuantity().intValue() : null)
-			.tradingPrice(indexData.getTradingPrice() != null ? indexData.getTradingPrice().intValue() : null)
+			.tradingQuantity(indexData.getTradingQuantity())
+			.tradingPrice(indexData.getTradingPrice() != null ? indexData.getTradingPrice().doubleValue() : null)
 			.marketTotalAmount(
-				indexData.getMarketTotalAmount() != null ? indexData.getMarketTotalAmount().intValue() : null)
+				indexData.getMarketTotalAmount() != null ? indexData.getMarketTotalAmount().doubleValue() : null)
 			.build();
 	}
 }

--- a/findex/src/main/java/com/codeit/findex/indexData/dto/IndexPerformanceRankResponse.java
+++ b/findex/src/main/java/com/codeit/findex/indexData/dto/IndexPerformanceRankResponse.java
@@ -1,0 +1,29 @@
+package com.codeit.findex.indexData.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class IndexPerformanceRankResponse {
+	private Performance performance;
+	private Integer rank;
+
+	@Getter
+	@Builder
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class Performance {
+		private Long indexInfoId;
+		private String indexClassification;
+		private String indexName;
+		private Float versus;
+		private Float fluctuationRate;
+		private Float currentPrice;
+		private Float beforePrice;
+	}
+}

--- a/findex/src/main/java/com/codeit/findex/indexData/dto/PagedResponseDto.java
+++ b/findex/src/main/java/com/codeit/findex/indexData/dto/PagedResponseDto.java
@@ -1,0 +1,21 @@
+package com.codeit.findex.indexData.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PagedResponseDto<T> {
+	private List<T> content;
+	private String nextCursor;
+	private String nextIdAfter;
+	private Integer size;
+	private Integer totalElements;
+	private boolean hasNext;
+}

--- a/findex/src/main/java/com/codeit/findex/indexData/repository/IndexDataRepository.java
+++ b/findex/src/main/java/com/codeit/findex/indexData/repository/IndexDataRepository.java
@@ -1,8 +1,27 @@
 package com.codeit.findex.indexData.repository;
 
+import java.time.LocalDate;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.codeit.findex.indexData.domain.IndexData;
 
 public interface IndexDataRepository extends JpaRepository<IndexData, Long> {
+
+	@Query("SELECT id FROM IndexData id " +
+		"LEFT JOIN FETCH id.indexInfo ii " +
+		"WHERE (:indexInfoId IS NULL OR id.indexInfo.id = :indexInfoId) " +
+		"AND (:startDate IS NULL OR id.baseDate >= :startDate) " +
+		"AND (:endDate IS NULL OR id.baseDate <= :endDate) " +
+		"AND (:idAfter IS NULL OR id.id > :idAfter)")
+	Page<IndexData> findIndexDataWithFilters(
+		@Param("indexInfoId") Long indexInfoId,
+		@Param("startDate") LocalDate startDate,
+		@Param("endDate") LocalDate endDate,
+		@Param("idAfter") Long idAfter,
+		Pageable pageable);
 }

--- a/findex/src/main/java/com/codeit/findex/indexData/repository/IndexDataRepository.java
+++ b/findex/src/main/java/com/codeit/findex/indexData/repository/IndexDataRepository.java
@@ -54,19 +54,12 @@ public interface IndexDataRepository extends JpaRepository<IndexData, Long> {
 		@Param("lastId") Long lastId,
 		Pageable pageable);
 
-	Optional<IndexData> findTopByIndexInfoIdAndBaseDateLessThanOrderByBaseDateDesc(
-		Long indexInfoId, LocalDate baseDate);
-
 	List<IndexData> findByIndexInfoIdAndBaseDateGreaterThanEqualOrderByBaseDateAsc(Long indexInfoId,
 		LocalDate startDate);
 
 	List<IndexData> findByIndexInfoIdOrderByBaseDateAsc(Long indexInfoId);
 
 	Optional<IndexData> findByIndexInfoIdAndBaseDate(Long indexInfoId, LocalDate baseDate);
-
-	List<IndexData> findAllByBaseDate(LocalDate baseDate);
-
-	List<IndexData> findByIndexInfoIdOrderByBaseDateDesc(Long indexInfoId);
 
 	@Query("SELECT MAX(id.baseDate) FROM IndexData id")
 	Optional<LocalDate> findMaxBaseDate();

--- a/findex/src/main/java/com/codeit/findex/indexData/repository/IndexDataRepository.java
+++ b/findex/src/main/java/com/codeit/findex/indexData/repository/IndexDataRepository.java
@@ -62,4 +62,16 @@ public interface IndexDataRepository extends JpaRepository<IndexData, Long> {
 
 	List<IndexData> findByIndexInfoIdOrderByBaseDateAsc(Long indexInfoId);
 
+	Optional<IndexData> findByIndexInfoIdAndBaseDate(Long indexInfoId, LocalDate baseDate);
+
+	List<IndexData> findAllByBaseDate(LocalDate baseDate);
+
+	List<IndexData> findByIndexInfoIdOrderByBaseDateDesc(Long indexInfoId);
+
+	@Query("SELECT MAX(id.baseDate) FROM IndexData id")
+	Optional<LocalDate> findMaxBaseDate();
+
+	@Query("SELECT MAX(id.baseDate) FROM IndexData id WHERE id.indexInfo.id = :indexInfoId")
+	Optional<LocalDate> findMaxBaseDateByIndexInfoId(@Param("indexInfoId") Long indexInfoId);
+
 }

--- a/findex/src/main/java/com/codeit/findex/indexData/repository/IndexDataRepository.java
+++ b/findex/src/main/java/com/codeit/findex/indexData/repository/IndexDataRepository.java
@@ -1,6 +1,7 @@
 package com.codeit.findex.indexData.repository;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -19,9 +20,12 @@ public interface IndexDataRepository extends JpaRepository<IndexData, Long> {
 		"AND (:endDate IS NULL OR id.baseDate <= :endDate) " +
 		"AND (:idAfter IS NULL OR id.id > :idAfter)")
 	Page<IndexData> findIndexDataWithFilters(
-		@Param("indexInfoId") Long indexInfoId,
+		@Param("indexInfoId") Integer indexInfoId,
 		@Param("startDate") LocalDate startDate,
 		@Param("endDate") LocalDate endDate,
-		@Param("idAfter") Long idAfter,
+		@Param("idAfter") Integer idAfter,
 		Pageable pageable);
+
+	Optional<IndexData> findTopByIndexInfoIdAndBaseDateLessThanOrderByBaseDateDesc(
+		Integer indexInfoId, LocalDate baseDate);
 }

--- a/findex/src/main/java/com/codeit/findex/indexData/repository/IndexDataRepository.java
+++ b/findex/src/main/java/com/codeit/findex/indexData/repository/IndexDataRepository.java
@@ -1,6 +1,7 @@
 package com.codeit.findex.indexData.repository;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -13,19 +14,52 @@ import com.codeit.findex.indexData.domain.IndexData;
 
 public interface IndexDataRepository extends JpaRepository<IndexData, Long> {
 
+	// 기본 조회 (첫 페이지)
+	@Query("SELECT id FROM IndexData id " +
+		"LEFT JOIN FETCH id.indexInfo ii " +
+		"WHERE (:indexInfoId IS NULL OR id.indexInfo.id = :indexInfoId) " +
+		"AND (:startDate IS NULL OR id.baseDate >= :startDate) " +
+		"AND (:endDate IS NULL OR id.baseDate <= :endDate)")
+	Page<IndexData> findIndexDataWithFilters(
+		@Param("indexInfoId") Long indexInfoId,
+		@Param("startDate") LocalDate startDate,
+		@Param("endDate") LocalDate endDate,
+		Pageable pageable);
+
+	// 오름차순 정렬용 커서 조회 (ID보다 큰 값)
 	@Query("SELECT id FROM IndexData id " +
 		"LEFT JOIN FETCH id.indexInfo ii " +
 		"WHERE (:indexInfoId IS NULL OR id.indexInfo.id = :indexInfoId) " +
 		"AND (:startDate IS NULL OR id.baseDate >= :startDate) " +
 		"AND (:endDate IS NULL OR id.baseDate <= :endDate) " +
-		"AND (:idAfter IS NULL OR id.id > :idAfter)")
-	Page<IndexData> findIndexDataWithFilters(
-		@Param("indexInfoId") Integer indexInfoId,
+		"AND id.id > :lastId")
+	Page<IndexData> findIndexDataWithFiltersAfterIdAsc(
+		@Param("indexInfoId") Long indexInfoId,
 		@Param("startDate") LocalDate startDate,
 		@Param("endDate") LocalDate endDate,
-		@Param("idAfter") Integer idAfter,
+		@Param("lastId") Long lastId,
+		Pageable pageable);
+
+	// 내림차순 정렬용 커서 조회 (ID보다 작은 값)
+	@Query("SELECT id FROM IndexData id " +
+		"LEFT JOIN FETCH id.indexInfo ii " +
+		"WHERE (:indexInfoId IS NULL OR id.indexInfo.id = :indexInfoId) " +
+		"AND (:startDate IS NULL OR id.baseDate >= :startDate) " +
+		"AND (:endDate IS NULL OR id.baseDate <= :endDate) " +
+		"AND id.id < :lastId")
+	Page<IndexData> findIndexDataWithFiltersAfterIdDesc(
+		@Param("indexInfoId") Long indexInfoId,
+		@Param("startDate") LocalDate startDate,
+		@Param("endDate") LocalDate endDate,
+		@Param("lastId") Long lastId,
 		Pageable pageable);
 
 	Optional<IndexData> findTopByIndexInfoIdAndBaseDateLessThanOrderByBaseDateDesc(
-		Integer indexInfoId, LocalDate baseDate);
+		Long indexInfoId, LocalDate baseDate);
+
+	List<IndexData> findByIndexInfoIdAndBaseDateGreaterThanEqualOrderByBaseDateAsc(Long indexInfoId,
+		LocalDate startDate);
+
+	List<IndexData> findByIndexInfoIdOrderByBaseDateAsc(Long indexInfoId);
+
 }

--- a/findex/src/main/java/com/codeit/findex/indexData/service/IndexChartService.java
+++ b/findex/src/main/java/com/codeit/findex/indexData/service/IndexChartService.java
@@ -1,0 +1,126 @@
+package com.codeit.findex.indexData.service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.codeit.findex.indexData.domain.IndexData;
+import com.codeit.findex.indexData.domain.PeriodType;
+import com.codeit.findex.indexData.dto.IndexChartResponse;
+import com.codeit.findex.indexData.repository.IndexDataRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class IndexChartService {
+	private final IndexDataRepository indexDataRepository;
+	private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+	public IndexChartResponse getIndexChartData(Long indexInfoId, PeriodType periodType) {
+		// 기간 계산
+		LocalDate startDate = calculateStartDate(periodType);
+
+		// 데이터 조회
+		List<IndexData> indexDataList = startDate != null
+			? indexDataRepository.findByIndexInfoIdAndBaseDateGreaterThanEqualOrderByBaseDateAsc(indexInfoId, startDate)
+			: indexDataRepository.findByIndexInfoIdOrderByBaseDateAsc(indexInfoId);
+
+		if (indexDataList.isEmpty()) {
+			throw new IllegalArgumentException("해당 지수 정보에 대한 데이터가 없습니다.");
+		}
+
+		// 지수 정보 조회
+		var indexInfo = indexDataList.get(0).getIndexInfo();
+
+		// 기간별 데이터 필터링
+		List<IndexData> filteredData = filterDataByPeriod(indexDataList, periodType);
+
+		// 차트 데이터 생성
+		List<IndexChartResponse.DataPoint> dataPoints = createDataPoints(filteredData);
+
+		// 이동평균선 계산
+		List<IndexChartResponse.DataPoint> ma5DataPoints = calculateMovingAverage(indexDataList, 5);
+		List<IndexChartResponse.DataPoint> ma20DataPoints = calculateMovingAverage(indexDataList, 20);
+
+		return IndexChartResponse.builder()
+			.indexInfoId(indexInfoId)
+			.indexClassification(indexInfo.getIndexClassification())
+			.indexName(indexInfo.getIndexName())
+			.periodType(periodType != null ? periodType.name() : "ALL")
+			.dataPoints(dataPoints)
+			.ma5DataPoints(ma5DataPoints)
+			.ma20DataPoints(ma20DataPoints)
+			.build();
+	}
+
+	private LocalDate calculateStartDate(PeriodType periodType) {
+		if (periodType == null)
+			return null;
+
+		LocalDate now = LocalDate.now();
+		return switch (periodType) {
+			case MONTHLY -> now.minusMonths(1);
+			case QUARTERLY -> now.minusMonths(3);
+			case YEARLY -> now.minusYears(1);
+		};
+	}
+
+	private List<IndexData> filterDataByPeriod(List<IndexData> dataList, PeriodType periodType) {
+		if (periodType == null)
+			return dataList;
+
+		LocalDate startDate = calculateStartDate(periodType);
+		return dataList.stream()
+			.filter(data -> !data.getBaseDate().isBefore(startDate))
+			.collect(Collectors.toList());
+	}
+
+	private List<IndexChartResponse.DataPoint> createDataPoints(List<IndexData> dataList) {
+		return dataList.stream()
+			.map(data -> IndexChartResponse.DataPoint.builder()
+				.date(data.getBaseDate().format(DATE_FORMATTER))
+				.value(data.getClosingPrice() != null ? data.getClosingPrice().floatValue() : 0f)
+				.build())
+			.collect(Collectors.toList());
+	}
+
+	private List<IndexChartResponse.DataPoint> calculateMovingAverage(List<IndexData> dataList, int period) {
+		List<IndexChartResponse.DataPoint> maDataPoints = new ArrayList<>();
+
+		if (dataList.size() < period) {
+			return maDataPoints;
+		}
+
+		for (int i = period - 1; i < dataList.size(); i++) {
+			BigDecimal sum = BigDecimal.ZERO;
+			int count = 0;
+
+			for (int j = i - period + 1; j <= i; j++) {
+				BigDecimal price = dataList.get(j).getClosingPrice();
+				if (price != null) {
+					sum = sum.add(price);
+					count++;
+				}
+			}
+
+			if (count > 0) {
+				float average = sum.divide(BigDecimal.valueOf(count), 2, RoundingMode.HALF_UP).floatValue();
+				maDataPoints.add(IndexChartResponse.DataPoint.builder()
+					.date(dataList.get(i).getBaseDate().format(DATE_FORMATTER))
+					.value(average)
+					.build());
+			}
+		}
+
+		return maDataPoints;
+	}
+}

--- a/findex/src/main/java/com/codeit/findex/indexData/service/IndexDataQueryService.java
+++ b/findex/src/main/java/com/codeit/findex/indexData/service/IndexDataQueryService.java
@@ -1,0 +1,63 @@
+package com.codeit.findex.indexData.service;
+
+import java.time.LocalDate;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.codeit.findex.indexData.domain.IndexData;
+import com.codeit.findex.indexData.repository.IndexDataRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class IndexDataQueryService {
+	private final IndexDataRepository indexDataRepository;
+
+	public Page<IndexData> getIndexDataList(Long indexInfoId, LocalDate startDate, LocalDate endDate,
+		Long lastId, String sortField, String sortDirection, Integer size) {
+
+		// 정렬 방향 설정
+		Sort.Direction direction = "desc".equalsIgnoreCase(sortDirection)
+			? Sort.Direction.DESC
+			: Sort.Direction.ASC;
+
+		String entitySortField = mapSortField(sortField);
+
+		// 보조 정렬로 ID 추가 (중복 값이 있을 때 일관성 보장)
+		Sort sort = Sort.by(direction, entitySortField).and(Sort.by(Sort.Direction.ASC, "id"));
+		Pageable pageable = PageRequest.of(0, size, sort);
+
+		Page<IndexData> result;
+		if (lastId != null) {
+			// 커서 기반 조회 - 정렬 방향에 따라 다른 조건 사용
+			if (direction == Sort.Direction.DESC) {
+				result = indexDataRepository.findIndexDataWithFiltersAfterIdDesc(
+					indexInfoId, startDate, endDate, lastId, pageable);
+			} else {
+				result = indexDataRepository.findIndexDataWithFiltersAfterIdAsc(
+					indexInfoId, startDate, endDate, lastId, pageable);
+			}
+		} else {
+			// 첫 페이지 조회
+			result = indexDataRepository.findIndexDataWithFilters(
+				indexInfoId, startDate, endDate, pageable);
+		}
+
+		return result;
+	}
+
+	private String mapSortField(String apiSortField) {
+		return switch (apiSortField) {
+			case "baseDate", "date" -> "baseDate";           // 날짜
+			case "closingPrice", "price" -> "closingPrice";  // 종가
+			default -> "baseDate";                           // 기본값: 날짜
+		};
+	}
+}

--- a/findex/src/main/java/com/codeit/findex/indexData/service/IndexDataService.java
+++ b/findex/src/main/java/com/codeit/findex/indexData/service/IndexDataService.java
@@ -1,8 +1,15 @@
 package com.codeit.findex.indexData.service;
 
+import java.time.LocalDate;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import com.codeit.findex.indexData.domain.IndexData;
 import com.codeit.findex.indexData.repository.IndexDataRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -12,4 +19,39 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class IndexDataService {
 	private final IndexDataRepository indexDataRepository;
+
+	// 지수 데이터 목록 조회
+	public Page<IndexData> getIndexDataList(Long indexInfoId, LocalDate startDate, LocalDate endDate,
+		Long idAfter, String sortField, String sortDirection, int size) {
+
+		// 정렬 방향 설정
+		Sort.Direction direction = "desc".equalsIgnoreCase(sortDirection)
+			? Sort.Direction.DESC
+			: Sort.Direction.ASC;
+
+		// 정렬 필드 매핑 (API 스펙의 sortField를 entity 필드로 매핑)
+		String entitySortField = mapSortField(sortField);
+
+		Sort sort = Sort.by(direction, entitySortField);
+		Pageable pageable = PageRequest.of(0, size, sort);
+
+		return indexDataRepository.findIndexDataWithFilters(
+			indexInfoId, startDate, endDate, idAfter, pageable);
+	}
+
+	private String mapSortField(String apiSortField) {
+		// API 스펙의 정렬 필드를 엔티티 필드로 매핑
+		switch (apiSortField) {
+			case "indexClassification":
+				return "indexInfo.indexClassification"; // Join 필드
+			case "indexName":
+				return "indexInfo.indexName"; // Join 필드
+			case "employedItemsCount":
+				return "indexInfo.employedItemsCount"; // Join 필드
+			case "baseDate":
+				return "baseDate";
+			default:
+				return "id"; // 기본값
+		}
+	}
 }

--- a/findex/src/main/java/com/codeit/findex/indexData/service/IndexDataService.java
+++ b/findex/src/main/java/com/codeit/findex/indexData/service/IndexDataService.java
@@ -1,77 +1,22 @@
 package com.codeit.findex.indexData.service;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.codeit.findex.indexData.domain.IndexData;
-import com.codeit.findex.indexData.domain.PeriodType;
-import com.codeit.findex.indexData.dto.IndexChartResponse;
 import com.codeit.findex.indexData.dto.IndexDataRequestDto;
 import com.codeit.findex.indexData.repository.IndexDataRepository;
 import com.codeit.findex.indexInfo.domain.IndexInfo;
 import com.codeit.findex.indexInfo.repository.IndexInfoRepository;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
+@Transactional
 public class IndexDataService {
 	private final IndexDataRepository indexDataRepository;
 	private final IndexInfoRepository indexInfoRepository;
-	private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-
-	public Page<IndexData> getIndexDataList(Long indexInfoId, LocalDate startDate, LocalDate endDate,
-		Long lastId, String sortField, String sortDirection, Integer size) {
-
-		// 정렬 방향 설정
-		Sort.Direction direction = "desc".equalsIgnoreCase(sortDirection)
-			? Sort.Direction.DESC
-			: Sort.Direction.ASC;
-
-		String entitySortField = mapSortField(sortField);
-
-		log.info("정렬 설정 - 필드: {}, 방향: {}, 매핑된 필드: {}, lastId: {}",
-			sortField, sortDirection, entitySortField, lastId);
-
-		// 보조 정렬로 ID 추가 (중복 값이 있을 때 일관성 보장)
-		Sort sort = Sort.by(direction, entitySortField).and(Sort.by(Sort.Direction.ASC, "id"));
-		Pageable pageable = PageRequest.of(0, size, sort);
-
-		Page<IndexData> result;
-		if (lastId != null) {
-			// 커서 기반 조회 - 정렬 방향에 따라 다른 조건 사용
-			if (direction == Sort.Direction.DESC) {
-				log.info("내림차순 커서 조회 - id < {}", lastId);
-				result = indexDataRepository.findIndexDataWithFiltersAfterIdDesc(
-					indexInfoId, startDate, endDate, lastId, pageable);
-			} else {
-				log.info("오름차순 커서 조회 - id > {}", lastId);
-				result = indexDataRepository.findIndexDataWithFiltersAfterIdAsc(
-					indexInfoId, startDate, endDate, lastId, pageable);
-			}
-			log.info("커서 기반 조회 완료 - 결과 수: {}", result.getContent().size());
-		} else {
-			// 첫 페이지 조회
-			result = indexDataRepository.findIndexDataWithFilters(
-				indexInfoId, startDate, endDate, pageable);
-			log.info("첫 페이지 조회 완료 - 결과 수: {}", result.getContent().size());
-		}
-
-		return result;
-	}
 
 	public IndexData createIndexData(IndexDataRequestDto requestDto) {
 		IndexInfo indexInfo = null;
@@ -82,112 +27,5 @@ public class IndexDataService {
 		IndexData indexData = requestDto.toEntity(indexInfo);
 
 		return indexDataRepository.save(indexData);
-	}
-
-	private String mapSortField(String apiSortField) {
-		return switch (apiSortField) {
-			case "baseDate", "date" -> "baseDate";           // 날짜
-			case "closingPrice", "price" -> "closingPrice";  // 종가
-			default -> "baseDate";                           // 기본값: 날짜
-		};
-	}
-
-	public IndexChartResponse getIndexChartData(Long indexInfoId, PeriodType periodType) {
-		// 기간 계산
-		LocalDate startDate = calculateStartDate(periodType);
-
-		// 데이터 조회
-		List<IndexData> indexDataList = startDate != null
-			? indexDataRepository.findByIndexInfoIdAndBaseDateGreaterThanEqualOrderByBaseDateAsc(indexInfoId, startDate)
-			: indexDataRepository.findByIndexInfoIdOrderByBaseDateAsc(indexInfoId);
-
-		if (indexDataList.isEmpty()) {
-			throw new IllegalArgumentException("해당 지수 정보에 대한 데이터가 없습니다.");
-		}
-
-		// 지수 정보 조회
-		var indexInfo = indexDataList.get(0).getIndexInfo();
-
-		// 기간별 데이터 필터링
-		List<IndexData> filteredData = filterDataByPeriod(indexDataList, periodType);
-
-		// 차트 데이터 생성
-		List<IndexChartResponse.DataPoint> dataPoints = createDataPoints(filteredData);
-
-		// 이동평균선 계산
-		List<IndexChartResponse.DataPoint> ma5DataPoints = calculateMovingAverage(indexDataList, 5);
-		List<IndexChartResponse.DataPoint> ma20DataPoints = calculateMovingAverage(indexDataList, 20);
-
-		return IndexChartResponse.builder()
-			.indexInfoId(indexInfoId)
-			.indexClassification(indexInfo.getIndexClassification())
-			.indexName(indexInfo.getIndexName())
-			.periodType(periodType != null ? periodType.name() : "ALL")
-			.dataPoints(dataPoints)
-			.ma5DataPoints(ma5DataPoints)
-			.ma20DataPoints(ma20DataPoints)
-			.build();
-	}
-
-	private LocalDate calculateStartDate(PeriodType periodType) {
-		if (periodType == null)
-			return null;
-
-		LocalDate now = LocalDate.now();
-		return switch (periodType) {
-			case MONTHLY -> now.minusMonths(1);
-			case QUARTERLY -> now.minusMonths(3);
-			case YEARLY -> now.minusYears(1);
-		};
-	}
-
-	private List<IndexData> filterDataByPeriod(List<IndexData> dataList, PeriodType periodType) {
-		if (periodType == null)
-			return dataList;
-
-		LocalDate startDate = calculateStartDate(periodType);
-		return dataList.stream()
-			.filter(data -> !data.getBaseDate().isBefore(startDate))
-			.collect(Collectors.toList());
-	}
-
-	private List<IndexChartResponse.DataPoint> createDataPoints(List<IndexData> dataList) {
-		return dataList.stream()
-			.map(data -> IndexChartResponse.DataPoint.builder()
-				.date(data.getBaseDate().format(DATE_FORMATTER))
-				.value(data.getClosingPrice() != null ? data.getClosingPrice().floatValue() : 0f)
-				.build())
-			.collect(Collectors.toList());
-	}
-
-	private List<IndexChartResponse.DataPoint> calculateMovingAverage(List<IndexData> dataList, int period) {
-		List<IndexChartResponse.DataPoint> maDataPoints = new ArrayList<>();
-
-		if (dataList.size() < period) {
-			return maDataPoints;
-		}
-
-		for (int i = period - 1; i < dataList.size(); i++) {
-			BigDecimal sum = BigDecimal.ZERO;
-			int count = 0;
-
-			for (int j = i - period + 1; j <= i; j++) {
-				BigDecimal price = dataList.get(j).getClosingPrice();
-				if (price != null) {
-					sum = sum.add(price);
-					count++;
-				}
-			}
-
-			if (count > 0) {
-				float average = sum.divide(BigDecimal.valueOf(count), 2, RoundingMode.HALF_UP).floatValue();
-				maDataPoints.add(IndexChartResponse.DataPoint.builder()
-					.date(dataList.get(i).getBaseDate().format(DATE_FORMATTER))
-					.value(average)
-					.build());
-			}
-		}
-
-		return maDataPoints;
 	}
 }

--- a/findex/src/main/java/com/codeit/findex/indexData/service/IndexDataService.java
+++ b/findex/src/main/java/com/codeit/findex/indexData/service/IndexDataService.java
@@ -1,5 +1,7 @@
 package com.codeit.findex.indexData.service;
 
+import static java.time.LocalDate.*;
+
 import java.time.LocalDate;
 
 import org.springframework.data.domain.Page;
@@ -21,8 +23,11 @@ public class IndexDataService {
 	private final IndexDataRepository indexDataRepository;
 
 	// 지수 데이터 목록 조회
-	public Page<IndexData> getIndexDataList(Long indexInfoId, LocalDate startDate, LocalDate endDate,
-		Long idAfter, String sortField, String sortDirection, int size) {
+	public Page<IndexData> getIndexDataList(Integer indexInfoId, String startDate, String endDate,
+		Integer idAfter, String sortField, String sortDirection, Integer size) {
+
+		LocalDate startLocalDate = parseDate(startDate);
+		LocalDate endLocalDate = parseDate(endDate);
 
 		// 정렬 방향 설정
 		Sort.Direction direction = "desc".equalsIgnoreCase(sortDirection)
@@ -35,21 +40,27 @@ public class IndexDataService {
 		Pageable pageable = PageRequest.of(0, size, sort);
 
 		return indexDataRepository.findIndexDataWithFilters(
-			indexInfoId, startDate, endDate, idAfter, pageable);
+			indexInfoId, startLocalDate, endLocalDate, idAfter, pageable);
+	}
+
+	private LocalDate parseDate(String dateString) {
+		if (dateString == null || dateString.trim().isEmpty()) {
+			return null;
+		}
+		try {
+			return LocalDate.parse(dateString);
+		} catch (Exception e) {
+			return null;
+		}
 	}
 
 	private String mapSortField(String apiSortField) {
-		switch (apiSortField) {
-			case "indexClassification":
-				return "indexInfo.indexClassification"; // Join 필드
-			case "indexName":
-				return "indexInfo.indexName"; // Join 필드
-			case "employedItemsCount":
-				return "indexInfo.employedItemsCount"; // Join 필드
-			case "baseDate":
-				return "baseDate";
-			default:
-				return "id"; // 기본값
-		}
+		return switch (apiSortField) {
+			case "indexClassification" -> "indexInfo.indexClassification"; // Join 필드
+			case "indexName" -> "indexInfo.indexName"; // Join 필드
+			case "employedItemsCount" -> "indexInfo.employedItemsCount"; // Join 필드
+			case "baseDate" -> "baseDate";
+			default -> "id"; // 기본값
+		};
 	}
 }

--- a/findex/src/main/java/com/codeit/findex/indexData/service/IndexDataService.java
+++ b/findex/src/main/java/com/codeit/findex/indexData/service/IndexDataService.java
@@ -1,33 +1,40 @@
 package com.codeit.findex.indexData.service;
 
-import static java.time.LocalDate.*;
-
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.RequestMapping;
 
 import com.codeit.findex.indexData.domain.IndexData;
+import com.codeit.findex.indexData.domain.PeriodType;
+import com.codeit.findex.indexData.dto.IndexChartResponse;
+import com.codeit.findex.indexData.dto.IndexDataRequestDto;
 import com.codeit.findex.indexData.repository.IndexDataRepository;
+import com.codeit.findex.indexInfo.domain.IndexInfo;
+import com.codeit.findex.indexInfo.repository.IndexInfoRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
-@RequestMapping("/api/index-data")
 @RequiredArgsConstructor
+@Slf4j
 public class IndexDataService {
 	private final IndexDataRepository indexDataRepository;
+	private final IndexInfoRepository indexInfoRepository;
+	private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
-	// 지수 데이터 목록 조회
-	public Page<IndexData> getIndexDataList(Integer indexInfoId, String startDate, String endDate,
-		Integer idAfter, String sortField, String sortDirection, Integer size) {
-
-		LocalDate startLocalDate = parseDate(startDate);
-		LocalDate endLocalDate = parseDate(endDate);
+	public Page<IndexData> getIndexDataList(Long indexInfoId, LocalDate startDate, LocalDate endDate,
+		Long lastId, String sortField, String sortDirection, Integer size) {
 
 		// 정렬 방향 설정
 		Sort.Direction direction = "desc".equalsIgnoreCase(sortDirection)
@@ -36,31 +43,151 @@ public class IndexDataService {
 
 		String entitySortField = mapSortField(sortField);
 
-		Sort sort = Sort.by(direction, entitySortField);
+		log.info("정렬 설정 - 필드: {}, 방향: {}, 매핑된 필드: {}, lastId: {}",
+			sortField, sortDirection, entitySortField, lastId);
+
+		// 보조 정렬로 ID 추가 (중복 값이 있을 때 일관성 보장)
+		Sort sort = Sort.by(direction, entitySortField).and(Sort.by(Sort.Direction.ASC, "id"));
 		Pageable pageable = PageRequest.of(0, size, sort);
 
-		return indexDataRepository.findIndexDataWithFilters(
-			indexInfoId, startLocalDate, endLocalDate, idAfter, pageable);
+		Page<IndexData> result;
+		if (lastId != null) {
+			// 커서 기반 조회 - 정렬 방향에 따라 다른 조건 사용
+			if (direction == Sort.Direction.DESC) {
+				log.info("내림차순 커서 조회 - id < {}", lastId);
+				result = indexDataRepository.findIndexDataWithFiltersAfterIdDesc(
+					indexInfoId, startDate, endDate, lastId, pageable);
+			} else {
+				log.info("오름차순 커서 조회 - id > {}", lastId);
+				result = indexDataRepository.findIndexDataWithFiltersAfterIdAsc(
+					indexInfoId, startDate, endDate, lastId, pageable);
+			}
+			log.info("커서 기반 조회 완료 - 결과 수: {}", result.getContent().size());
+		} else {
+			// 첫 페이지 조회
+			result = indexDataRepository.findIndexDataWithFilters(
+				indexInfoId, startDate, endDate, pageable);
+			log.info("첫 페이지 조회 완료 - 결과 수: {}", result.getContent().size());
+		}
+
+		return result;
 	}
 
-	private LocalDate parseDate(String dateString) {
-		if (dateString == null || dateString.trim().isEmpty()) {
-			return null;
+	public IndexData createIndexData(IndexDataRequestDto requestDto) {
+		IndexInfo indexInfo = null;
+		if (requestDto.getIndexInfoId() != null) {
+			indexInfo = indexInfoRepository.findById(requestDto.getIndexInfoId())
+				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 지수 정보 ID입니다: " + requestDto.getIndexInfoId()));
 		}
-		try {
-			return LocalDate.parse(dateString);
-		} catch (Exception e) {
-			return null;
-		}
+		IndexData indexData = requestDto.toEntity(indexInfo);
+
+		return indexDataRepository.save(indexData);
 	}
 
 	private String mapSortField(String apiSortField) {
 		return switch (apiSortField) {
-			case "indexClassification" -> "indexInfo.indexClassification"; // Join 필드
-			case "indexName" -> "indexInfo.indexName"; // Join 필드
-			case "employedItemsCount" -> "indexInfo.employedItemsCount"; // Join 필드
-			case "baseDate" -> "baseDate";
-			default -> "id"; // 기본값
+			case "baseDate", "date" -> "baseDate";           // 날짜
+			case "closingPrice", "price" -> "closingPrice";  // 종가
+			default -> "baseDate";                           // 기본값: 날짜
 		};
+	}
+
+	public IndexChartResponse getIndexChartData(Long indexInfoId, PeriodType periodType) {
+		// 기간 계산
+		LocalDate startDate = calculateStartDate(periodType);
+
+		// 데이터 조회
+		List<IndexData> indexDataList = startDate != null
+			? indexDataRepository.findByIndexInfoIdAndBaseDateGreaterThanEqualOrderByBaseDateAsc(indexInfoId, startDate)
+			: indexDataRepository.findByIndexInfoIdOrderByBaseDateAsc(indexInfoId);
+
+		if (indexDataList.isEmpty()) {
+			throw new IllegalArgumentException("해당 지수 정보에 대한 데이터가 없습니다.");
+		}
+
+		// 지수 정보 조회
+		var indexInfo = indexDataList.get(0).getIndexInfo();
+
+		// 기간별 데이터 필터링
+		List<IndexData> filteredData = filterDataByPeriod(indexDataList, periodType);
+
+		// 차트 데이터 생성
+		List<IndexChartResponse.DataPoint> dataPoints = createDataPoints(filteredData);
+
+		// 이동평균선 계산
+		List<IndexChartResponse.DataPoint> ma5DataPoints = calculateMovingAverage(indexDataList, 5);
+		List<IndexChartResponse.DataPoint> ma20DataPoints = calculateMovingAverage(indexDataList, 20);
+
+		return IndexChartResponse.builder()
+			.indexInfoId(indexInfoId)
+			.indexClassification(indexInfo.getIndexClassification())
+			.indexName(indexInfo.getIndexName())
+			.periodType(periodType != null ? periodType.name() : "ALL")
+			.dataPoints(dataPoints)
+			.ma5DataPoints(ma5DataPoints)
+			.ma20DataPoints(ma20DataPoints)
+			.build();
+	}
+
+	private LocalDate calculateStartDate(PeriodType periodType) {
+		if (periodType == null)
+			return null;
+
+		LocalDate now = LocalDate.now();
+		return switch (periodType) {
+			case MONTHLY -> now.minusMonths(1);
+			case QUARTERLY -> now.minusMonths(3);
+			case YEARLY -> now.minusYears(1);
+		};
+	}
+
+	private List<IndexData> filterDataByPeriod(List<IndexData> dataList, PeriodType periodType) {
+		if (periodType == null)
+			return dataList;
+
+		LocalDate startDate = calculateStartDate(periodType);
+		return dataList.stream()
+			.filter(data -> !data.getBaseDate().isBefore(startDate))
+			.collect(Collectors.toList());
+	}
+
+	private List<IndexChartResponse.DataPoint> createDataPoints(List<IndexData> dataList) {
+		return dataList.stream()
+			.map(data -> IndexChartResponse.DataPoint.builder()
+				.date(data.getBaseDate().format(DATE_FORMATTER))
+				.value(data.getClosingPrice() != null ? data.getClosingPrice().floatValue() : 0f)
+				.build())
+			.collect(Collectors.toList());
+	}
+
+	private List<IndexChartResponse.DataPoint> calculateMovingAverage(List<IndexData> dataList, int period) {
+		List<IndexChartResponse.DataPoint> maDataPoints = new ArrayList<>();
+
+		if (dataList.size() < period) {
+			return maDataPoints;
+		}
+
+		for (int i = period - 1; i < dataList.size(); i++) {
+			BigDecimal sum = BigDecimal.ZERO;
+			int count = 0;
+
+			for (int j = i - period + 1; j <= i; j++) {
+				BigDecimal price = dataList.get(j).getClosingPrice();
+				if (price != null) {
+					sum = sum.add(price);
+					count++;
+				}
+			}
+
+			if (count > 0) {
+				float average = sum.divide(BigDecimal.valueOf(count), 2, RoundingMode.HALF_UP).floatValue();
+				maDataPoints.add(IndexChartResponse.DataPoint.builder()
+					.date(dataList.get(i).getBaseDate().format(DATE_FORMATTER))
+					.value(average)
+					.build());
+			}
+		}
+
+		return maDataPoints;
 	}
 }

--- a/findex/src/main/java/com/codeit/findex/indexData/service/IndexDataService.java
+++ b/findex/src/main/java/com/codeit/findex/indexData/service/IndexDataService.java
@@ -29,7 +29,6 @@ public class IndexDataService {
 			? Sort.Direction.DESC
 			: Sort.Direction.ASC;
 
-		// 정렬 필드 매핑 (API 스펙의 sortField를 entity 필드로 매핑)
 		String entitySortField = mapSortField(sortField);
 
 		Sort sort = Sort.by(direction, entitySortField);
@@ -40,7 +39,6 @@ public class IndexDataService {
 	}
 
 	private String mapSortField(String apiSortField) {
-		// API 스펙의 정렬 필드를 엔티티 필드로 매핑
 		switch (apiSortField) {
 			case "indexClassification":
 				return "indexInfo.indexClassification"; // Join 필드

--- a/findex/src/main/java/com/codeit/findex/indexData/service/IndexPerformanceService.java
+++ b/findex/src/main/java/com/codeit/findex/indexData/service/IndexPerformanceService.java
@@ -1,0 +1,263 @@
+package com.codeit.findex.indexData.service;
+
+import com.codeit.findex.indexData.domain.IndexData;
+import com.codeit.findex.indexData.domain.PerformancePeriodType;
+import com.codeit.findex.indexData.dto.IndexPerformanceRankResponse;
+import com.codeit.findex.indexData.repository.IndexDataRepository;
+import com.codeit.findex.indexInfo.domain.IndexInfo;
+import com.codeit.findex.indexInfo.repository.IndexInfoRepository;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class IndexPerformanceService {
+
+	private final IndexDataRepository indexDataRepository;
+	private final IndexInfoRepository indexInfoRepository;
+
+	public List<IndexPerformanceRankResponse> getPerformanceRanking(
+		Long indexInfoId,
+		PerformancePeriodType periodType,
+		Integer limit) {
+
+		// 기본값 설정
+		if (periodType == null) {
+			periodType = PerformancePeriodType.DAILY;
+		}
+		if (limit == null || limit <= 0) {
+			limit = 10;
+		}
+
+		// 최신 거래일 조회
+		LocalDate latestDate = indexDataRepository.findMaxBaseDate()
+			.orElseThrow(() -> new IllegalStateException("거래 데이터가 없습니다."));
+
+		// 비교 기준일 계산
+		LocalDate compareDate = calculateCompareDate(latestDate, periodType);
+
+		List<IndexPerformanceRankResponse> rankings;
+
+		if (indexInfoId != null) {
+			// 특정 지수의 랭킹 조회
+			rankings = getSpecificIndexRanking(indexInfoId, latestDate, compareDate, periodType);
+		} else {
+			// 전체 지수 랭킹 조회
+			rankings = getAllIndexRanking(latestDate, compareDate, limit);
+		}
+
+		return rankings;
+	}
+
+	private LocalDate calculateCompareDate(LocalDate baseDate, PerformancePeriodType periodType) {
+		return switch (periodType) {
+			case DAILY -> getPreviousTradingDay(baseDate);
+			case WEEKLY -> baseDate.minusWeeks(1);
+			case MONTHLY -> baseDate.minusMonths(1);
+		};
+	}
+
+	private LocalDate getPreviousTradingDay(LocalDate date) {
+		LocalDate previousDay = date.minusDays(1);
+
+		// 주말인 경우 금요일로 조정
+		if (previousDay.getDayOfWeek() == DayOfWeek.SATURDAY) {
+			previousDay = previousDay.minusDays(1);
+		} else if (previousDay.getDayOfWeek() == DayOfWeek.SUNDAY) {
+			previousDay = previousDay.minusDays(2);
+		}
+
+		return previousDay;
+	}
+
+	private List<IndexPerformanceRankResponse> getAllIndexRanking(
+		LocalDate latestDate,
+		LocalDate compareDate,
+		Integer limit) {
+
+		// 모든 지수 정보 조회
+		List<IndexInfo> allIndexInfos = indexInfoRepository.findAll();
+
+		// 성과 계산 및 정렬
+		List<IndexPerformanceData> performanceDataList = new ArrayList<>();
+
+		for (IndexInfo indexInfo : allIndexInfos) {
+			Optional<IndexData> currentDataOpt = indexDataRepository
+				.findByIndexInfoIdAndBaseDate(indexInfo.getId(), latestDate);
+			Optional<IndexData> compareDataOpt = indexDataRepository
+				.findByIndexInfoIdAndBaseDate(indexInfo.getId(), compareDate);
+
+			if (currentDataOpt.isPresent() && compareDataOpt.isPresent()) {
+				IndexPerformanceData perfData = calculatePerformance(
+					indexInfo, currentDataOpt.get(), compareDataOpt.get());
+				performanceDataList.add(perfData);
+			}
+		}
+
+		// 등락률 기준 내림차순 정렬
+		performanceDataList.sort((a, b) ->
+			Float.compare(b.getFluctuationRate(), a.getFluctuationRate()));
+
+		// 상위 N개만 선택하고 랭킹 부여
+		return performanceDataList.stream()
+			.limit(limit)
+			.map((perfData) -> {
+				int rank = performanceDataList.indexOf(perfData) + 1;
+				return createRankResponse(perfData, rank);
+			})
+			.collect(Collectors.toList());
+	}
+
+	private List<IndexPerformanceRankResponse> getSpecificIndexRanking(
+		Long indexInfoId,
+		LocalDate latestDate,
+		LocalDate compareDate,
+		PerformancePeriodType periodType) {
+
+		IndexInfo indexInfo = indexInfoRepository.findById(indexInfoId)
+			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 지수 정보입니다."));
+
+		// 해당 지수의 최신 데이터 조회
+		Optional<IndexData> currentDataOpt = indexDataRepository
+			.findByIndexInfoIdAndBaseDate(indexInfoId, latestDate);
+
+		if (currentDataOpt.isEmpty()) {
+			// 최신 거래일에 데이터가 없으면 가장 최근 데이터 조회
+			Optional<LocalDate> maxDate = indexDataRepository
+				.findMaxBaseDateByIndexInfoId(indexInfoId);
+			if (maxDate.isEmpty()) {
+				throw new IllegalArgumentException("해당 지수의 거래 데이터가 없습니다.");
+			}
+			latestDate = maxDate.get();
+			compareDate = calculateCompareDate(latestDate, periodType);
+			currentDataOpt = indexDataRepository.findByIndexInfoIdAndBaseDate(indexInfoId, latestDate);
+		}
+
+		Optional<IndexData> compareDataOpt = indexDataRepository
+			.findByIndexInfoIdAndBaseDate(indexInfoId, compareDate);
+
+		if (currentDataOpt.isEmpty() || compareDataOpt.isEmpty()) {
+			throw new IllegalArgumentException("성과 계산을 위한 데이터가 부족합니다.");
+		}
+
+		IndexPerformanceData perfData = calculatePerformance(
+			indexInfo, currentDataOpt.get(), compareDataOpt.get());
+
+		// 전체 지수 중 순위 계산
+		int rank = calculateRankAmongAll(perfData.getFluctuationRate(), latestDate, compareDate);
+
+		return List.of(createRankResponse(perfData, rank));
+	}
+
+	private int calculateRankAmongAll(float targetFluctuationRate,
+		LocalDate latestDate,
+		LocalDate compareDate) {
+		List<IndexInfo> allIndexInfos = indexInfoRepository.findAll();
+		int rank = 1;
+
+		for (IndexInfo indexInfo : allIndexInfos) {
+			Optional<IndexData> currentOpt = indexDataRepository
+				.findByIndexInfoIdAndBaseDate(indexInfo.getId(), latestDate);
+			Optional<IndexData> compareOpt = indexDataRepository
+				.findByIndexInfoIdAndBaseDate(indexInfo.getId(), compareDate);
+
+			if (currentOpt.isPresent() && compareOpt.isPresent()) {
+				float fluctuationRate = calculateFluctuationRate(
+					currentOpt.get().getClosingPrice(),
+					compareOpt.get().getClosingPrice());
+
+				if (fluctuationRate > targetFluctuationRate) {
+					rank++;
+				}
+			}
+		}
+
+		return rank;
+	}
+
+	private IndexPerformanceData calculatePerformance(
+		IndexInfo indexInfo,
+		IndexData currentData,
+		IndexData compareData) {
+
+		BigDecimal currentPrice = currentData.getClosingPrice();
+		BigDecimal beforePrice = compareData.getClosingPrice();
+
+		if (currentPrice == null || beforePrice == null || beforePrice.compareTo(BigDecimal.ZERO) == 0) {
+			return IndexPerformanceData.builder()
+				.indexInfo(indexInfo)
+				.currentPrice(currentPrice != null ? currentPrice.floatValue() : 0f)
+				.beforePrice(beforePrice != null ? beforePrice.floatValue() : 0f)
+				.versus(0f)
+				.fluctuationRate(0f)
+				.build();
+		}
+
+		// 전일 대비 = 현재가 - 이전가
+		BigDecimal versus = currentPrice.subtract(beforePrice);
+
+		// 등락률 = (현재가 - 이전가) / 이전가 * 100
+		float fluctuationRate = calculateFluctuationRate(currentPrice, beforePrice);
+
+		return IndexPerformanceData.builder()
+			.indexInfo(indexInfo)
+			.currentPrice(currentPrice.floatValue())
+			.beforePrice(beforePrice.floatValue())
+			.versus(versus.floatValue())
+			.fluctuationRate(fluctuationRate)
+			.build();
+	}
+
+	private float calculateFluctuationRate(BigDecimal currentPrice, BigDecimal beforePrice) {
+		if (beforePrice.compareTo(BigDecimal.ZERO) == 0) {
+			return 0f;
+		}
+
+		return currentPrice.subtract(beforePrice)
+			.divide(beforePrice, 4, RoundingMode.HALF_UP)
+			.multiply(BigDecimal.valueOf(100))
+			.floatValue();
+	}
+
+	private IndexPerformanceRankResponse createRankResponse(
+		IndexPerformanceData perfData,
+		int rank) {
+
+		return IndexPerformanceRankResponse.builder()
+			.performance(IndexPerformanceRankResponse.Performance.builder()
+				.indexInfoId(perfData.getIndexInfo().getId())
+				.indexClassification(perfData.getIndexInfo().getIndexClassification())
+				.indexName(perfData.getIndexInfo().getIndexName())
+				.versus(perfData.getVersus())
+				.fluctuationRate(perfData.getFluctuationRate())
+				.currentPrice(perfData.getCurrentPrice())
+				.beforePrice(perfData.getBeforePrice())
+				.build())
+			.rank(rank)
+			.build();
+	}
+
+	@Getter
+	@Builder
+	private static class IndexPerformanceData {
+		private IndexInfo indexInfo;
+		private Float currentPrice;
+		private Float beforePrice;
+		private Float versus;
+		private Float fluctuationRate;
+	}
+}

--- a/findex/src/main/resources/application-local.yml
+++ b/findex/src/main/resources/application-local.yml
@@ -3,8 +3,8 @@ spring:
     name: findex
   datasource:
     url: jdbc:postgresql://localhost:5432/findex
-    username: findex_user
-    password: findex1234
+    username: postgres
+    password: 1234
     driver-class-name: org.postgresql.Driver
 
   jpa:

--- a/findex/src/main/resources/sql/dummy.sql
+++ b/findex/src/main/resources/sql/dummy.sql
@@ -1,23 +1,30 @@
 BEGIN;
 
 -- (선택) 이전에 넣었던 DEMO 데이터가 있으면 정리하고 싶을 때 주석 해제
--- DELETE FROM auto_sync_configs  WHERE index_info_id IN (SELECT id FROM index_infos WHERE index_name LIKE 'DEMO-INDEX-%');
--- DELETE FROM index_data        WHERE index_info_id IN (SELECT id FROM index_infos WHERE index_name LIKE 'DEMO-INDEX-%');
--- DELETE FROM sync_jobs         WHERE (index_info_id IN (SELECT id FROM index_infos WHERE index_name LIKE 'DEMO-INDEX-%') OR index_info_id IS NULL);
--- DELETE FROM index_infos       WHERE index_name LIKE 'DEMO-INDEX-%';
+DELETE
+FROM auto_sync_configs
+WHERE index_info_id IN (SELECT id FROM index_infos WHERE index_name LIKE 'DEMO-INDEX-%');
+DELETE
+FROM index_data
+WHERE index_info_id IN (SELECT id FROM index_infos WHERE index_name LIKE 'DEMO-INDEX-%');
+DELETE
+FROM sync_jobs
+WHERE (index_info_id IN (SELECT id FROM index_infos WHERE index_name LIKE 'DEMO-INDEX-%') OR index_info_id IS NULL);
+DELETE
+FROM index_infos
+WHERE index_name LIKE 'DEMO-INDEX-%';
 
 -- 1) index_infos 50개
 INSERT INTO index_infos
-(index_name,               index_classification,                                 employed_items_count, base_point_in_time,                 base_index,                          source_type, favorite)
-SELECT
-    format('DEMO-INDEX-%02s', gs)                                                  AS index_name,
-    (ARRAY['KOSPI시리즈','KOSDAQ시리즈','KRX100','테마'])[(random()*3)::int+1]      AS index_classification,
-    (50 + (random()*450)::int)                                                     AS employed_items_count,
-    DATE '2000-01-01' + ((random()*7000)::int)                                     AS base_point_in_time,
-    ROUND((500 + random()*2500)::numeric, 4)                                       AS base_index,
-    'OPEN_API'                                                                     AS source_type,
-    (random() < 0.2)                                                               AS favorite
-FROM generate_series(1,50) AS gs;
+(index_name, index_classification, employed_items_count, base_point_in_time, base_index, source_type, favorite)
+SELECT format('DEMO-INDEX-%02s', gs)                                           AS index_name,
+       (ARRAY ['KOSPI시리즈','KOSDAQ시리즈','KRX100','테마'])[(random() * 3)::int + 1] AS index_classification,
+       (50 + (random() * 450)::int)                                            AS employed_items_count,
+       DATE '2000-01-01' + ((random() * 7000)::int)                            AS base_point_in_time,
+       ROUND((500 + random() * 2500)::numeric, 4)                              AS base_index,
+       'OPEN_API'                                                              AS source_type,
+       (random() < 0.2)                                                        AS favorite
+FROM generate_series(1, 50) AS gs;
 
 -- 2) auto_sync_configs 50개 (DEMO 인덱스에 대해 1:1)
 INSERT INTO auto_sync_configs (index_info_id, enabled)
@@ -28,63 +35,66 @@ ORDER BY id;
 
 -- 3) index_data 50개 (DEMO 인덱스 각각 1행씩)
 INSERT INTO index_data
-(index_info_id, base_date,     source_type, market_price, closing_price, high_price, low_price,
- versus, fluctuation_rate, trading_quantity, trading_price,                     market_total_amount)
-SELECT
-    s.id                                                     AS index_info_id,
-    DATE '2024-01-01'                                        AS base_date,
-    'OPEN_API'                                               AS source_type,
-    mp.mkt                                                   AS market_price,
-    mp.cls                                                   AS closing_price,
-    hl.highp                                                 AS high_price,
-    hl.lowp                                                  AS low_price,
-    ROUND((mp.cls - mp.mkt)::numeric, 4)                     AS versus,
-    ROUND((CASE WHEN mp.mkt = 0 THEN 0 ELSE ((mp.cls - mp.mkt)/mp.mkt)*100 END)::numeric, 4) AS fluctuation_rate,
-    s.qty                                                    AS trading_quantity,
-    (s.qty::numeric * FLOOR(mp.cls*100)::numeric)            AS trading_price,
-    (s.qty::numeric * FLOOR(mp.cls*1000)::numeric)           AS market_total_amount
-FROM (
-         SELECT ii.id,
-                (FLOOR(random()*9000000)::bigint + 100000) AS qty
-         FROM index_infos ii
-         WHERE ii.index_name LIKE 'DEMO-INDEX-%'
-         ORDER BY ii.id
-     ) s
+(index_info_id, base_date, source_type, market_price, closing_price, high_price, low_price,
+ versus, fluctuation_rate, trading_quantity, trading_price, market_total_amount)
+SELECT s.id                                                                                         AS index_info_id,
+       DATE '2024-01-01'                                                                            AS base_date,
+       'OPEN_API'                                                                                   AS source_type,
+       mp.mkt                                                                                       AS market_price,
+       mp.cls                                                                                       AS closing_price,
+       hl.highp                                                                                     AS high_price,
+       hl.lowp                                                                                      AS low_price,
+       ROUND((mp.cls - mp.mkt)::numeric, 4)                                                         AS versus,
+       ROUND((CASE WHEN mp.mkt = 0 THEN 0 ELSE ((mp.cls - mp.mkt) / mp.mkt) * 100 END)::numeric, 4) AS fluctuation_rate,
+       s.qty                                                                                        AS trading_quantity,
+       (s.qty::numeric * FLOOR(mp.cls * 100)::numeric)                                              AS trading_price,
+       (s.qty::numeric * FLOOR(mp.cls * 1000)::numeric)                                             AS market_total_amount
+FROM (SELECT ii.id,
+             (FLOOR(random() * 9000000)::bigint + 100000) AS qty
+      FROM index_infos ii
+      WHERE ii.index_name LIKE 'DEMO-INDEX-%'
+      ORDER BY ii.id) s
          CROSS JOIN LATERAL (
-    SELECT
-        ROUND((500 + random()*2500 + (random()*10-5))::numeric, 4) AS mkt,
-        ROUND((500 + random()*2500 + (random()*10-5))::numeric, 4) AS cls
+    SELECT ROUND((500 + random() * 2500 + (random() * 10 - 5))::numeric, 4) AS mkt,
+           ROUND((500 + random() * 2500 + (random() * 10 - 5))::numeric, 4) AS cls
     ) mp
          CROSS JOIN LATERAL (
-    SELECT
-        ROUND((GREATEST(mp.mkt, mp.cls) + (random()*5))::numeric, 4) AS highp,
-        ROUND((LEAST(mp.mkt, mp.cls)  - (random()*5))::numeric, 4)   AS lowp
+    SELECT ROUND((GREATEST(mp.mkt, mp.cls) + (random() * 5))::numeric, 4) AS highp,
+           ROUND((LEAST(mp.mkt, mp.cls) - (random() * 5))::numeric, 4)    AS lowp
     ) hl;
 
 -- 4) sync_jobs 50개
 INSERT INTO sync_jobs
-(index_info_id, job_type,     target_date,                                                     worker,                                                   job_time,                                   result)
-SELECT
-    CASE WHEN jt.job_type = 'INDEX_INFO' AND r.rnull < 0.4 THEN NULL ELSE ii.id END AS index_info_id,
-    jt.job_type,
-    CASE WHEN jt.job_type = 'INDEX_DATA' THEN (DATE '2024-01-01' + ((random()*30)::int)) ELSE NULL END AS target_date,
-    (ARRAY['batcher','scheduler','ops','admin'])[(random()*3)::int+1]                     AS worker,
-    NOW() - (random() * (INTERVAL '15 days'))                                             AS job_time,
-    CASE WHEN random() < 0.9 THEN 'SUCCESS' ELSE 'FAILED' END                              AS result
-FROM (
-         SELECT id
-         FROM index_infos
-         WHERE index_name LIKE 'DEMO-INDEX-%'
-         ORDER BY id
-         LIMIT 50
-     ) ii
+    (index_info_id, job_type, target_date, worker, job_time, result)
+SELECT CASE WHEN jt.job_type = 'INDEX_INFO' AND r.rnull < 0.4 THEN NULL ELSE ii.id END AS index_info_id,
+       jt.job_type,
+       CASE
+           WHEN jt.job_type = 'INDEX_DATA' THEN (DATE '2024-01-01' + ((random() * 30)::int))
+           ELSE NULL END                                                               AS target_date,
+       (ARRAY ['batcher','scheduler','ops','admin'])[(random() * 3)::int + 1]          AS worker,
+       NOW() - (random() * (INTERVAL '15 days'))                                       AS job_time,
+       CASE WHEN random() < 0.9 THEN 'SUCCESS' ELSE 'FAILED' END                       AS result
+FROM (SELECT id
+      FROM index_infos
+      WHERE index_name LIKE 'DEMO-INDEX-%'
+      ORDER BY id
+      LIMIT 50) ii
          CROSS JOIN LATERAL (SELECT CASE WHEN random() < 0.5 THEN 'INDEX_INFO' ELSE 'INDEX_DATA' END AS job_type) jt
          CROSS JOIN LATERAL (SELECT random() AS rnull) r;
 
 COMMIT;
 
 
-SELECT COUNT(*) FROM index_infos        WHERE index_name LIKE 'DEMO-INDEX-%';
-SELECT COUNT(*) FROM auto_sync_configs  a JOIN index_infos i ON a.index_info_id=i.id WHERE i.index_name LIKE 'DEMO-INDEX-%';
-SELECT COUNT(*) FROM index_data         d JOIN index_infos i ON d.index_info_id=i.id WHERE i.index_name LIKE 'DEMO-INDEX-%';
-SELECT COUNT(*) FROM sync_jobs;
+SELECT COUNT(*)
+FROM index_infos
+WHERE index_name LIKE 'DEMO-INDEX-%';
+SELECT COUNT(*)
+FROM auto_sync_configs a
+         JOIN index_infos i ON a.index_info_id = i.id
+WHERE i.index_name LIKE 'DEMO-INDEX-%';
+SELECT COUNT(*)
+FROM index_data d
+         JOIN index_infos i ON d.index_info_id = i.id
+WHERE i.index_name LIKE 'DEMO-INDEX-%';
+SELECT COUNT(*)
+FROM sync_jobs;


### PR DESCRIPTION
### 작업 개요
지수 데이터 관리 API 및 자동 연동 설정 API 기능 구현

### 작업 분류
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 상세 내용
- 지수 데이터 목록 조회 로직 리팩토링
- 지수 versus 값 호출 및 조회 방식 개선
- Service, Controller 클래스 기능별로 분리
- 지수 성과 랭킹 조회 기능 추가
- key-value 관련 API 명세서와 일치하도록 수정
- Repository에서 미사용 메서드 삭제 및 누락 파일 추가

### 생각해볼 문제
1. 지수 데이터 등록 및 지수 차트 조회 시 지수 정보 관리 API가 구현되어 있어야 로컬 사이트에서 돌아가기 때문에, 합쳤을 때 제대로 작동하는지 확인해 볼 필요가 있을 것 같습니다. 
