### PR TITLE
feat : 전체 데이터 6시 00분 스케줄러 추가 및 자동 연동 파트 테이블 연동

### DIFF
--- a/findex/src/main/java/com/codeit/findex/common/openapi/controller/ApiDataInitializer.java
+++ b/findex/src/main/java/com/codeit/findex/common/openapi/controller/ApiDataInitializer.java
@@ -1,30 +1,30 @@
-package com.codeit.findex.common.openapi.controller;
-
-import org.springframework.boot.CommandLineRunner;
-import org.springframework.stereotype.Component;
-
-import com.codeit.findex.common.openapi.service.ApiIndexDataService;
-import com.codeit.findex.common.openapi.service.ApiIndexInfoService;
-
-import lombok.RequiredArgsConstructor;
-
-@Component
-@RequiredArgsConstructor
-public class ApiDataInitializer implements CommandLineRunner {
-
-	private final ApiIndexInfoService indexInfoService;
-	private final ApiIndexDataService indexDataService;
-
-	@Override
-	public void run(String... args) throws Exception {
-		System.out.println("Starting data collection...");
-
-		System.out.println("Step 1: Collecting IndexInfo data...");
-		indexInfoService.fetchAndSaveIndexInfo();
-
-		System.out.println("Step 2: Collecting IndexData...");
-		indexDataService.fetchAndSaveIndexData();
-
-		System.out.println("All data collection complete!");
-	}
-}
+// package com.codeit.findex.common.openapi.controller;
+//
+// import org.springframework.boot.CommandLineRunner;
+// import org.springframework.stereotype.Component;
+//
+// import com.codeit.findex.common.openapi.service.ApiIndexDataService;
+// import com.codeit.findex.common.openapi.service.ApiIndexInfoService;
+//
+// import lombok.RequiredArgsConstructor;
+//
+// @Component
+// @RequiredArgsConstructor
+// public class ApiDataInitializer implements CommandLineRunner {
+//
+// 	private final ApiIndexInfoService indexInfoService;
+// 	private final ApiIndexDataService indexDataService;
+//
+// 	@Override
+// 	public void run(String... args) throws Exception {
+// 		System.out.println("Starting data collection...");
+//
+// 		System.out.println("Step 1: Collecting IndexInfo data...");
+// 		indexInfoService.fetchAndSaveIndexInfo();
+//
+// 		System.out.println("Step 2: Collecting IndexData...");
+// 		indexDataService.fetchAndSaveIndexData();
+//
+// 		System.out.println("All data collection complete!");
+// 	}
+// }

--- a/findex/src/main/java/com/codeit/findex/common/openapi/scheduler/ApiFullFetchScheduler.java
+++ b/findex/src/main/java/com/codeit/findex/common/openapi/scheduler/ApiFullFetchScheduler.java
@@ -1,0 +1,101 @@
+// com.codeit.findex.common.openapi.scheduler.ApiFullFetchScheduler
+package com.codeit.findex.common.openapi.scheduler;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.jdbc.core.ConnectionCallback;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.codeit.findex.common.openapi.service.ApiIndexDataService;
+import com.codeit.findex.common.openapi.service.ApiIndexInfoService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ApiFullFetchScheduler {
+
+	private final ApiIndexInfoService indexInfoService;
+	private final ApiIndexDataService indexDataService;
+	private final JdbcTemplate jdbcTemplate; // 동일 커넥션에서 lock/unlock 수행
+
+	@Value("${findex.scheduler.fullfetch.enabled:true}")
+	private boolean enabled;
+
+	@Value("${findex.scheduler.fullfetch.run-on-startup:false}")
+	private boolean runOnStartup;
+
+	private static final String LOCK_KEY_EXPR = "hashtext('findex_fullfetch_daily')";
+
+	//서버 시작 직후 1회 실행
+	@EventListener(ApplicationReadyEvent.class)
+	public void runOnceOnStartup() {
+		if (runOnStartup) {
+			log.info("[FullFetch] run once on startup");
+			runOnceWithLock();
+		}
+	}
+
+	@Scheduled(
+		cron = "${findex.scheduler.fullfetch.cron}",
+		zone = "${findex.scheduler.fullfetch.zone:Asia/Seoul}"
+	)
+	public void runFullFetch() {
+		runOnceWithLock();
+	}
+
+	private void runOnceWithLock() {
+		if (!enabled) {
+			log.info("[FullFetch] disabled; skip.");
+			return;
+		}
+
+		jdbcTemplate.execute((ConnectionCallback<Void>)con -> {
+			try (var stmt = con.createStatement()) {
+				// 1) try lock
+				boolean locked = false;
+				try (ResultSet rs = stmt.executeQuery(
+					"SELECT pg_try_advisory_lock(" + LOCK_KEY_EXPR + ")")) {
+					if (rs.next()) {
+						locked = rs.getBoolean(1);
+					}
+				}
+				if (!locked) {
+					log.warn("[FullFetch] another instance is running; skip.");
+					return null;
+				}
+
+				// 2) 실제 작업
+				try {
+					log.info("[FullFetch] start: IndexInfo -> IndexData (team parser services)");
+					indexInfoService.fetchAndSaveIndexInfo();  // 팀원 파싱/저장 서비스
+					indexDataService.fetchAndSaveIndexData();  // 팀원 파싱/저장 서비스
+					log.info("[FullFetch] done");
+				} catch (Exception e) {
+					log.error("[FullFetch] failed", e);
+					throw e;
+				} finally {
+					// 3) unlock (결과 boolean 반환)
+					try (ResultSet rs2 = stmt.executeQuery(
+						"SELECT pg_advisory_unlock(" + LOCK_KEY_EXPR + ")")) {
+						if (rs2.next()) {
+							boolean unlocked = rs2.getBoolean(1);
+							log.debug("[FullFetch] unlock={}", unlocked);
+						}
+					} catch (SQLException unlockEx) {
+						log.warn("[FullFetch] unlock failed", unlockEx);
+					}
+				}
+			}
+			return null;
+		});
+	}
+}

--- a/findex/src/main/java/com/codeit/findex/openApi/repository/AutoSyncConfigRepository.java
+++ b/findex/src/main/java/com/codeit/findex/openApi/repository/AutoSyncConfigRepository.java
@@ -12,6 +12,8 @@ public interface AutoSyncConfigRepository extends
 	JpaRepository<AutoSyncConfig, Long>,
 	JpaSpecificationExecutor<AutoSyncConfig> {
 
+	boolean existsByIndexInfoId(Long indexInfoId);
+
 	@Override
 	@EntityGraph(attributePaths = {"indexInfo"})
 	Page<AutoSyncConfig> findAll(Specification<AutoSyncConfig> spec, Pageable pageable);

--- a/findex/src/main/java/com/codeit/findex/openApi/scheduler/AutoSyncScheduler.java
+++ b/findex/src/main/java/com/codeit/findex/openApi/scheduler/AutoSyncScheduler.java
@@ -19,8 +19,8 @@ public class AutoSyncScheduler {
 
 	// 기본: 매일 06:05 (KST). 로컬에선 아래 3)에서 cron 바꿔서 빠르게 테스트 가능.
 	@Scheduled(
-		cron = "${auto-sync.scheduler.cron:20 0 0 * * *}",
-		// cron = "${auto-sync.scheduler.cron:0 5 6 * * *}",
+		// cron = "${auto-sync.scheduler.cron:20 0 0 * * *}",
+		cron = "${auto-sync.scheduler.cron:0 0 6 * * *}",
 		zone = "${auto-sync.scheduler.zone:Asia/Seoul}"
 	)
 	public void run() {

--- a/findex/src/main/java/com/codeit/findex/openApi/service/AutoSyncConfigService.java
+++ b/findex/src/main/java/com/codeit/findex/openApi/service/AutoSyncConfigService.java
@@ -1,5 +1,6 @@
 package com.codeit.findex.openApi.service;
 
+import com.codeit.findex.indexInfo.domain.IndexInfo;
 import com.codeit.findex.openApi.domain.AutoSyncConfig;
 import com.codeit.findex.openApi.dto.AutoSyncConfigDto;
 import com.codeit.findex.openApi.dto.request.AutoSyncConfigUpdateRequest;
@@ -150,5 +151,17 @@ public class AutoSyncConfigService {
 		entity.setEnabled(request.getEnabled());
 		return AutoSyncConfigMapper.toDto(entity);
 	}
+
+	@Transactional
+	public void ensureExists(IndexInfo indexInfo) {
+		if (repository.existsByIndexInfoId(indexInfo.getId()))
+			return;
+
+		AutoSyncConfig cfg = new AutoSyncConfig();
+		cfg.setIndexInfo(indexInfo);
+		cfg.setEnabled(false); // 기본 OFF
+		repository.save(cfg);
+	}
+
 }
 

--- a/findex/src/main/java/com/codeit/findex/openApi/spec/AutoSyncConfigBackfillRunner.java
+++ b/findex/src/main/java/com/codeit/findex/openApi/spec/AutoSyncConfigBackfillRunner.java
@@ -1,0 +1,40 @@
+package com.codeit.findex.openApi.spec;
+
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.codeit.findex.indexInfo.domain.IndexInfo;
+import com.codeit.findex.indexInfo.repository.IndexInfoRepository;
+import com.codeit.findex.openApi.domain.AutoSyncConfig;
+import com.codeit.findex.openApi.repository.AutoSyncConfigRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AutoSyncConfigBackfillRunner {
+
+	private final IndexInfoRepository indexInfoRepository;
+	private final AutoSyncConfigRepository autoSyncConfigRepository;
+
+	@EventListener(ApplicationReadyEvent.class)
+	@Transactional
+	public void backfill() {
+		var all = indexInfoRepository.findAll();
+		int created = 0;
+		for (IndexInfo info : all) {
+			if (!autoSyncConfigRepository.existsByIndexInfoId(info.getId())) {
+				AutoSyncConfig cfg = new AutoSyncConfig();
+				cfg.setIndexInfo(info);
+				cfg.setEnabled(false);
+				autoSyncConfigRepository.save(cfg);
+				created++;
+			}
+		}
+		log.info("[AutoSync] backfill created {} configs", created);
+	}
+}

--- a/findex/src/main/resources/application-local.yml
+++ b/findex/src/main/resources/application-local.yml
@@ -29,3 +29,19 @@ logging:
 api:
   service-key: '4e45f20039574765ef0b52364e6ba488dde012627aef89847dccacb39fb77f0d'
   stock-url: 'https://apis.data.go.kr/1160100/service/GetMarketIndexInfoService/getStockMarketIndex'
+
+# scheduler
+# 전체 수집 스케줄러
+findex:
+  scheduler:
+    fullfetch:
+      enabled: true
+      cron: "0 0 6 * * *"   # 원하는 시간
+      zone: "Asia/Seoul"
+
+# 자동 연동 스케줄러
+auto-sync:
+  scheduler:
+    enabled: true
+    cron: "0 0 6 * * *"     # AutoSync: 매일 06:05
+    zone: "Asia/Seoul"


### PR DESCRIPTION
### 작업 개요
openAPI 데이터에 스케줄러 기능 추가

### 작업 분류
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 상세 내용
1. openAPI 데이터에 오전 6시 스케줄러 기능 추가
2. Auto_Sync_configs 테이블에 index_infos 테이블 값이 들어오면 자동으로 들어오게 추가

