### PR TITLE
fix: index_info 데이터 내림차순 에러 수정

### DIFF
--- a/findex/src/main/java/com/codeit/findex/indexInfo/repository/IndexInfoRepository.java
+++ b/findex/src/main/java/com/codeit/findex/indexInfo/repository/IndexInfoRepository.java
@@ -25,7 +25,8 @@ public interface IndexInfoRepository extends JpaRepository<IndexInfo,Long> {
 			    order by 
 			        case when :sortDirection = 'asc' then i.indexClassification end asc,
 			        case when :sortDirection = 'desc' then i.indexClassification end desc,
-			        i.id asc
+			        case when :sortDirection = 'asc' then i.id end asc,
+			        case when :sortDirection = 'desc' then i.id end desc
 			"""
 	)
 	Slice<IndexInfo> findAllByIndexClassificationCursor(
@@ -50,7 +51,8 @@ public interface IndexInfoRepository extends JpaRepository<IndexInfo,Long> {
         order by 
             case when :sortDirection = 'asc' then i.indexName end asc,
             case when :sortDirection = 'desc' then i.indexName end desc,
-            i.id asc
+            case when :sortDirection = 'asc' then i.id end asc,
+            case when :sortDirection = 'desc' then i.id end desc
     """
 	)
 	Slice<IndexInfo> findAllByIndexNameCursor(
@@ -75,7 +77,8 @@ public interface IndexInfoRepository extends JpaRepository<IndexInfo,Long> {
         order by 
             case when :sortDirection = 'asc' then i.employedItemsCount end asc,
             case when :sortDirection = 'desc' then i.employedItemsCount end desc,
-            i.id asc
+            case when :sortDirection = 'asc' then i.id end asc,
+            case when :sortDirection = 'desc' then i.id end desc
     """
 	)
 	Slice<IndexInfo> findAllByEmployedItemsCountCursor(
@@ -106,4 +109,3 @@ public interface IndexInfoRepository extends JpaRepository<IndexInfo,Long> {
 
 	List<IndexInfo> findByFavoriteTrue();
 }
-


### PR DESCRIPTION
### 작업 개요
index_info 데이터 내림차순 에러 수정

### 작업 분류
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 상세 내용
문제 상황
WHERE절: 내림차순 시 i.id < :idAfter 조건 사용
ORDER BY절: i.id asc로 항상 오름차순 고정

발생한 모순
커서 페이지네이션은 WHERE절 비교 방향과 ORDER BY 정렬 방향 일치 필요
내림차순 정렬 시 id는 작은 값을 찾으면서(<) 오름차순 정렬하는 논리적 충돌
결과적으로 내림차순 페이지네이션 오작동
