### PR TITLE
fix: index_info 데이터 수정시 "사용자"로 표시되게끔 수정

### DIFF
--- a/findex/src/main/java/com/codeit/findex/indexInfo/service/IndexInfoService.java
+++ b/findex/src/main/java/com/codeit/findex/indexInfo/service/IndexInfoService.java
@@ -131,17 +131,27 @@ public class IndexInfoService {
 		IndexInfo originIndexInfo = indexInfoRepository.getIndexInfoById(Long.valueOf(id))
 			.orElseThrow(NoSuchElementException::new);
 
+		boolean isChanged = false;
+
 		if (dto.getEmployedItemsCount() != null) {
 			originIndexInfo.setEmployedItemsCount(dto.getEmployedItemsCount());
+			isChanged = true;
 		}
 		if (dto.getBasePointInTime() != null) {
 			originIndexInfo.setBasePointInTime(LocalDate.parse(dto.getBasePointInTime()));
+			isChanged = true;
 		}
 		if (dto.getBaseIndex() != null) {
 			originIndexInfo.setBaseIndex(BigDecimal.valueOf(dto.getBaseIndex()));
+			isChanged = true;
 		}
 		if (dto.getFavorite() != null) {
 			originIndexInfo.setFavorite(dto.getFavorite());
+			isChanged = true;
+		}
+
+		if(isChanged){
+			originIndexInfo.setSourceType("USER");
 		}
 
 		IndexInfo updatedIndexInfo = indexInfoRepository.save(originIndexInfo);

--- a/findex/src/main/java/com/codeit/findex/openApi/service/AutoSyncConfigService.java
+++ b/findex/src/main/java/com/codeit/findex/openApi/service/AutoSyncConfigService.java
@@ -154,8 +154,11 @@ public class AutoSyncConfigService {
 
 	@Transactional
 	public void ensureExists(IndexInfo indexInfo) {
-		if (repository.existsByIndexInfoId(indexInfo.getId()))
+
+		if (repository.existsByIndexInfoId(indexInfo.getId())) {
+			indexInfo.setSourceType("OPEN_API");
 			return;
+		}
 
 		AutoSyncConfig cfg = new AutoSyncConfig();
 		cfg.setIndexInfo(indexInfo);


### PR DESCRIPTION
### 작업 개요
기존 지수 관리에서 데이터 수정 시 "OPEN API"로 유지되는 것을 "사용자"로 바뀌도록 수정

이후 "Open API 연동"을 클릭하면 다시 "OPEN API"로 바뀌도록 수정

### 작업 분류
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

