### PR TITLE
feat: 활성화된 지수 자동 연동 기능 추가

### DIFF
--- a/findex/src/main/java/com/codeit/findex/openApi/repository/AutoSyncConfigRepository.java
+++ b/findex/src/main/java/com/codeit/findex/openApi/repository/AutoSyncConfigRepository.java
@@ -1,5 +1,7 @@
 package com.codeit.findex.openApi.repository;
 
+import java.util.List;
+
 import com.codeit.findex.openApi.domain.AutoSyncConfig;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -7,6 +9,7 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.repository.Query;
 
 public interface AutoSyncConfigRepository extends
 	JpaRepository<AutoSyncConfig, Long>,
@@ -17,4 +20,8 @@ public interface AutoSyncConfigRepository extends
 	@Override
 	@EntityGraph(attributePaths = {"indexInfo"})
 	Page<AutoSyncConfig> findAll(Specification<AutoSyncConfig> spec, Pageable pageable);
+
+	@EntityGraph(attributePaths = {"indexInfo"})
+	@Query("select c from AutoSyncConfig c where c.enabled = true")
+	List<AutoSyncConfig> findAllByEnabledTrueWithIndexInfo();
 }

--- a/findex/src/main/java/com/codeit/findex/openApi/scheduler/AutoSyncScheduler.java
+++ b/findex/src/main/java/com/codeit/findex/openApi/scheduler/AutoSyncScheduler.java
@@ -1,38 +1,38 @@
-package com.codeit.findex.openApi.scheduler;
-
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Component;
-
-import com.codeit.findex.openApi.service.AutoSyncService;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
-@Slf4j
-@Component
-@RequiredArgsConstructor
-@ConditionalOnProperty(prefix = "auto-sync.scheduler", name = "enabled", havingValue = "true")
-public class AutoSyncScheduler {
-
-	private final AutoSyncService autoSyncService;
-
-	// 기본: 매일 06:05 (KST). 로컬에선 아래 3)에서 cron 바꿔서 빠르게 테스트 가능.
-	@Scheduled(
-		cron = "${auto-sync.scheduler.cron:20 0 0 * * *}",
-		// cron = "${auto-sync.scheduler.cron:0 5 6 * * *}",
-		zone = "${auto-sync.scheduler.zone:Asia/Seoul}"
-	)
-	public void run() {
-		try {
-			int processed = autoSyncService.syncEnabledConfigs(null);
-			log.info("[AutoSyncScheduler] processed={}", processed);
-		} catch (IllegalStateException e) {
-			// 이미 실행 중(락 실패) → 조용히 스킵
-			log.info("[AutoSyncScheduler] already running, skip");
-		} catch (Exception e) {
-			// 예기치 못한 실패 로깅
-			log.error("[AutoSyncScheduler] failed", e);
-		}
-	}
-}
+// package com.codeit.findex.openApi.scheduler;
+//
+// import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+// import org.springframework.scheduling.annotation.Scheduled;
+// import org.springframework.stereotype.Component;
+//
+// import com.codeit.findex.openApi.service.AutoSyncService;
+//
+// import lombok.RequiredArgsConstructor;
+// import lombok.extern.slf4j.Slf4j;
+//
+// @Slf4j
+// @Component
+// @RequiredArgsConstructor
+// @ConditionalOnProperty(prefix = "auto-sync.scheduler", name = "enabled", havingValue = "true")
+// public class AutoSyncScheduler {
+//
+// 	private final AutoSyncService autoSyncService;
+//
+// 	// 기본: 매일 06:05 (KST). 로컬에선 아래 3)에서 cron 바꿔서 빠르게 테스트 가능.
+// 	@Scheduled(
+// 		cron = "${auto-sync.scheduler.cron:20 0 0 * * *}",
+// 		// cron = "${auto-sync.scheduler.cron:0 5 6 * * *}",
+// 		zone = "${auto-sync.scheduler.zone:Asia/Seoul}"
+// 	)
+// 	public void run() {
+// 		try {
+// 			int processed = autoSyncService.syncEnabledConfigs(null);
+// 			log.info("[AutoSyncScheduler] processed={}", processed);
+// 		} catch (IllegalStateException e) {
+// 			// 이미 실행 중(락 실패) → 조용히 스킵
+// 			log.info("[AutoSyncScheduler] already running, skip");
+// 		} catch (Exception e) {
+// 			// 예기치 못한 실패 로깅
+// 			log.error("[AutoSyncScheduler] failed", e);
+// 		}
+// 	}
+// }

--- a/findex/src/main/java/com/codeit/findex/openApi/scheduler/DailyEnabledIndexSyncScheduler.java
+++ b/findex/src/main/java/com/codeit/findex/openApi/scheduler/DailyEnabledIndexSyncScheduler.java
@@ -1,0 +1,52 @@
+package com.codeit.findex.openApi.scheduler;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.codeit.findex.common.openapi.service.ApiIndexDataService;
+import com.codeit.findex.openApi.domain.AutoSyncConfig;
+import com.codeit.findex.openApi.repository.AutoSyncConfigRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "auto-sync.scheduler", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class DailyEnabledIndexSyncScheduler {
+
+	private final AutoSyncConfigRepository autoSyncConfigRepository;
+	private final ApiIndexDataService apiIndexDataService;
+
+	@Scheduled(cron = "${auto-sync.scheduler.cron}", zone = "${auto-sync.scheduler.zone}")
+	public void runDaily() {
+		LocalDate targetDate = LocalDate.now(ZoneId.of("Asia/Seoul")).minusDays(1);
+
+		// var → 명시적 타입
+		List<AutoSyncConfig> enabled = autoSyncConfigRepository.findAllByEnabledTrueWithIndexInfo();
+		if (enabled.isEmpty()) {
+			log.info("[AutoSync] enabled=true 대상 없음. skip. targetDate={}", targetDate);
+			return;
+		}
+
+		Set<String> allowedKeys = enabled.stream()
+			.map(cfg -> cfg.getIndexInfo().getIndexName() + "_" + String.valueOf(cfg.getIndexInfo().getIndexClassification()))
+			.collect(Collectors.toSet());
+
+		try {
+			int saved = apiIndexDataService.fetchAndSaveIndexDataFiltered(allowedKeys, targetDate);
+			log.info("[AutoSync] 완료 targetDate={} 대상={}건, 저장/업데이트={}건",
+				targetDate, allowedKeys.size(), saved);
+		} catch (Exception e) {
+			log.error("[AutoSync] 실패 targetDate={} keys={}", targetDate, allowedKeys, e);
+		}
+	}
+}


### PR DESCRIPTION
### 작업 개요
활성화된 지수 자동 연동 기능 추가

### 작업 분류
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 상세 내용 
1. 활성화된 지수의 지수 정보와 지수 데이터를 매일 오전 6시에 자동으로 연동(파싱)하는 스케줄러 추가